### PR TITLE
ECIP-1054: Move to last call state.

### DIFF
--- a/ECIPs/ECIP-1054.md
+++ b/ECIPs/ECIP-1054.md
@@ -2,7 +2,7 @@
 
     ECIP: 1054
     Title: Atlantis EVM and Protocol Upgrades
-    Status: Draft
+    Status: Last Call
     Type: Standards Track
     Author: Isaac Ardis <isaac.a@etclabs.org>
     Created: 2019-02-11
@@ -59,6 +59,8 @@ Technical specifications for each EIP can be found at those documents respective
 - [EIP 211](https://eips.ethereum.org/EIPS/eip-211) (New opcodes `RETURNDATASIZE` and `RETURNDATACOPY`)
 - [EIP 214](https://eips.ethereum.org/EIPS/eip-214) (New opcode `STATICCALL`)
 - [EIP 658](https://eips.ethereum.org/EIPS/eip-658) (Embedding transaction status code in receipts)
+
+In case any of the before mentioned proposals define a variable similar to the pattern `*_FORK_BLKNUM` named after _Spurious Dragon_ or _Byzantium_, it shall be replaced by a `ATLANTIS_FORK_BLKNUM`.
 
 ### Rationale
 


### PR DESCRIPTION
- ECIP-1054: Move to last call state.
- ECIP-1054: Explicitly override with `ATLANTIS_FORK_BLKNUM`