### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When you believe your ECIP is mature and ready to progress past the draft phase,
 * **Draft** - An ECIP was submitted by its author and is undergoing rapid iteration and changes.
 * **Last Call** - An ECIP that is done with its initial iteration and ready for review by a wider audience.
 * **Accepted** - An ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. If Core Devs decide to implement an ECIP into their clients, the ECIP will move to final.
-* **Final (non-Core)** - An ECIP that has been in Last Call for at least 2 weeks, any technical changes that were requested have been addressed by the author, and Core Devs decided to encode it into their clients. 
+* **Final (non-Core)** - An ECIP that has been in Last Call for at least 2 weeks, any technical changes that were requested have been addressed by the author, and Core Devs decided to implement it into their clients. 
 * **Final (Core)** - An ECIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork. 
 * **Deferred** - An ECIP that is not being considered for immediate adoption. May be reconsidered in the future for a subsequent hard fork.
 * **Replaced/Obsolete** - When a Final ECIP is no longer relevant, its status may be changed to Replaced or Obsolete (which is equivalent to Replaced).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When you believe your ECIP is mature and ready to progress past the draft phase,
 # ECIP Status Terms
 * **Draft** - An ECIP was submitted by its author and is undergoing rapid iteration and changes.
 * **Last Call** - An ECIP that is done with its initial iteration and ready for review by a wider audience.
-* **Accepted** - An ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. If Core Devs decide to encode an ECIP into their clients, the ECIP will move to final.
+* **Accepted** - An ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. If Core Devs decide to implement an ECIP into their clients, the ECIP will move to final.
 * **Final (non-Core)** - An ECIP that has been in Last Call for at least 2 weeks, any technical changes that were requested have been addressed by the author, and Core Devs decided to encode it into their clients. 
 * **Final (Core)** - An ECIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork. 
 * **Deferred** - An ECIP that is not being considered for immediate adoption. May be reconsidered in the future for a subsequent hard fork.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If your ECIP requires images, the image files should be included in a subdirecto
 When you believe your ECIP is mature and ready to progress past the draft phase, you should do one of two things:
 
  - **For a Standards Track ECIP of type Core**, ask to have your issue added to the agenda of an upcoming All Dev Team meeting, where it can be discussed for inclusion in a future hard fork. If implementers agree to include it, the ECIP editors will update the state of your ECIP to 'Accepted'.
- - **For all other ECIPs**, open a PR changing the state of your ECIP to 'Final'. An editor will review your draft and ask if anyone objects to its being finalised. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the ECIP - they may close the PR and request that you fix the issues in the draft before trying again.
+ - **For all other ECIPs**, open a PR changing the state of your ECIP to 'Final'. An editor will review your draft and ask if anyone objects to it being finalized. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the ECIP - they may close the PR and request that you fix the issues in the draft before trying again.
 
 # ECIP Status Terms
 * **Draft** - An ECIP was submitted by its author and is undergoing rapid iteration and changes.

--- a/README.md
+++ b/README.md
@@ -20,16 +20,15 @@ When you believe your ECIP is mature and ready to progress past the draft phase,
  - **For a Standards Track ECIP of type Core**, ask to have your issue added to the agenda of an upcoming All Dev Team meeting, where it can be discussed for inclusion in a future hard fork. If implementers agree to include it, the ECIP editors will update the state of your ECIP to 'Accepted'.
  - **For all other ECIPs**, open a PR changing the state of your ECIP to 'Final'. An editor will review your draft and ask if anyone objects to it being finalized. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the ECIP - they may close the PR and request that you fix the issues in the draft before trying again.
 
-# ECIP Status Terms
 * **Draft** - An ECIP was submitted by its author and is undergoing rapid iteration and changes.
 * **Last Call** - An ECIP that is done with its initial iteration and ready for review by a wider audience.
 * **Accepted** - An ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. If Core Devs decide to implement an ECIP into their clients, the ECIP will move to final.
 * **Final (non-Core)** - An ECIP that has been in Last Call for at least 2 weeks, any technical changes that were requested have been addressed by the author, and Core Devs decided to implement it into their clients. 
 * **Final (Core)** - An ECIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork. 
 * **Deferred** - An ECIP that is not being considered for immediate adoption. May be reconsidered in the future for a subsequent hard fork.
-* **Replaced/Obsolete** - When a Final ECIP is no longer relevant, its status may be changed to Replaced or Obsolete (which is equivalent to Replaced).
-* **Rejected** - Reasons for rejecting ECIPs include duplication of effort, disregard for formatting rules, being too unfocused or too broad, being technically unsound, not providing proper motivation or addressing backwards compatibility, or not in keeping with the Ethereum Classic philosophy.
-* **Withdrawn** - ECIP authors may decide on their own to change the status between Draft, Deferred, or Withdrawn. The ECIP editor may also change the status to Deferred when no progress is being made on the ECIP.
+* **Replaced** - When a Final ECIP is no longer relevant, its status may be changed to Replaced or Obsolete.
+* **Rejected** - Reasons for rejecting ECIPs include duplication of effort, disregard for formatting rules, unfocused or too broad, being technically unsound, not providing proper motivation, or conflicting with the decentralization, backward compatibility, and state finality of the network.
+* **Withdrawn** - ECIP authors may decide to change the status between Draft, Deferred, or Withdrawn. The ECIP editor may also change the status to Deferred if no progress is being made on the ECIP.
 
 # Accepted ECIPs
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,16 @@ If your ECIP requires images, the image files should be included in a subdirecto
 When you believe your ECIP is mature and ready to progress past the draft phase, you should do one of two things:
 
  - **For a Standards Track ECIP of type Core**, ask to have your issue added to the agenda of an upcoming All Dev Team meeting, where it can be discussed for inclusion in a future hard fork. If implementers agree to include it, the ECIP editors will update the state of your ECIP to 'Accepted'.
- - **For all other ECIPs**, open a PR changing the state of your ECIP to 'Final'. An editor will review your draft and ask if anyone objects to it being finalized. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the ECIP - they may close the PR and request that you fix the issues in the draft before trying again.
+ - **For all other ECIPs**, open a PR changing the state of your ECIP to 'Final'. An editor will review your draft and ask if anyone objects to its finalization. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the ECIP - they may close the PR and request that you fix the issues in the draft before trying again.
 
 # ECIP Status Terms
-* **Draft** - An ECIP was submitted by its author and is undergoing rapid iteration and changes.
+* **Draft** - An ECIP that is undergoing rapid iteration and changes.
 * **Last Call** - An ECIP that is done with its initial iteration and ready for review by a wider audience.
-* **Accepted** - An ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. If Core Devs decide to implement an ECIP into their clients, the ECIP will move to final.
-* **Final (non-Core)** - An ECIP that has been in Last Call for at least 2 weeks, any technical changes that were requested have been addressed by the author, and Core Devs decided to implement it into their clients. 
-* **Final (Core)** - An ECIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork. 
+* **Accepted** - An ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. 
+* **Final** - An ECIP that was accepted, implemented, and no longer can be modified without submitting a new proposal, e.g., it has been released in a hard fork. 
 * **Deferred** - An ECIP that is not being considered for immediate adoption. May be reconsidered in the future for a subsequent hard fork.
 * **Replaced** - When a Final ECIP is no longer relevant, its status may be changed to Replaced or Obsolete.
-* **Rejected** - Reasons for rejecting ECIPs include duplication of effort, disregard for formatting rules, unfocused or too broad, being technically unsound, not providing proper motivation, or conflicting with the decentralization, backward compatibility, and state finality of the network.
+* **Rejected** - Reasons for rejecting ECIPs include duplication of effort, disregard for formatting rules, unfocused or too broad, being technically unsound, not providing proper motivation, or obvious popular disapproval.
 * **Withdrawn** - ECIP authors may decide to change the status between Draft, Deferred, or Withdrawn. The ECIP editor may also change the status to Deferred if no progress is being made on the ECIP.
 
 # Accepted ECIPs

--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ When you believe your ECIP is mature and ready to progress past the draft phase,
  - **For all other ECIPs**, open a PR changing the state of your ECIP to 'Final'. An editor will review your draft and ask if anyone objects to its being finalised. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the ECIP - they may close the PR and request that you fix the issues in the draft before trying again.
 
 # ECIP Status Terms
-* **Draft** - an ECIP that is undergoing rapid iteration and changes
-* **Last Call** - an ECIP that is done with its initial iteration and ready for review by a wide audience
-* **Final (non-Core)** - an ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author.
-* **Final (Core)** - an ECIP that the dev teams have decide to implement and release in a future hard fork or has already been released in a hard fork
-* **Accepted** - a core ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author
-
-* **Deferred** - an ECIP that is not being considered for immediate adoption. May be reconsidered in the future for a subsequent hard fork.
+* **Draft** - An ECIP was submitted by its author and is undergoing rapid iteration and changes.
+* **Last Call** - An ECIP that is done with its initial iteration and ready for review by a wider audience.
+* **Accepted** - An ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. If Core Devs decide to encode an ECIP into their clients, the ECIP will move to final.
+* **Final (non-Core)** - An ECIP that has been in Last Call for at least 2 weeks, any technical changes that were requested have been addressed by the author, and Core Devs decided to encode it into their clients. 
+* **Final (Core)** - An ECIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork. 
+* **Deferred** - An ECIP that is not being considered for immediate adoption. May be reconsidered in the future for a subsequent hard fork.
+* **Replaced/Obsolete** - When a Final ECIP is no longer relevant, its status may be changed to Replaced or Obsolete (which is equivalent to Replaced).
+* **Rejected** - Reasons for rejecting ECIPs include duplication of effort, disregard for formatting rules, being too unfocused or too broad, being technically unsound, not providing proper motivation or addressing backwards compatibility, or not in keeping with the Ethereum Classic philosophy.
+* **Withdrawn** - ECIP authors may decide on their own to change the status between Draft, Deferred, or Withdrawn. The ECIP editor may also change the status to Deferred when no progress is being made on the ECIP.
 
 # Accepted ECIPs
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ When you believe your ECIP is mature and ready to progress past the draft phase,
  - **For a Standards Track ECIP of type Core**, ask to have your issue added to the agenda of an upcoming All Dev Team meeting, where it can be discussed for inclusion in a future hard fork. If implementers agree to include it, the ECIP editors will update the state of your ECIP to 'Accepted'.
  - **For all other ECIPs**, open a PR changing the state of your ECIP to 'Final'. An editor will review your draft and ask if anyone objects to it being finalized. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the ECIP - they may close the PR and request that you fix the issues in the draft before trying again.
 
+# ECIP Status Terms
 * **Draft** - An ECIP was submitted by its author and is undergoing rapid iteration and changes.
 * **Last Call** - An ECIP that is done with its initial iteration and ready for review by a wider audience.
 * **Accepted** - An ECIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. If Core Devs decide to implement an ECIP into their clients, the ECIP will move to final.


### PR DESCRIPTION
Reorganize ECIP Status terms for clarity and to make them easier to follow. (Proposed this change both on ethereumclassic ECIPs and etclabscore ECIPs).