### PR TITLE
Add domain setting for this repository

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+ecips.ethereumclassic.org


### PR DESCRIPTION
This prepares the repo to be served as a website under ecips.ethereumclassic.org.