### PR TITLE
Changed the preamble box and corrected ECIP-1000 status

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -1,14 +1,12 @@
----
-lang: en
-ecip: 1000
-title: ECIP Process
-status: Active
-type: Meta
-discussions-to: https://github.com/ethereumclassic/ECIPs/issues/58
-author: Wei Tang (@sorpaas)
-created: 2017-06-29
-license: Apache-2
----
+	lang: en
+	ecip: 1000
+	title: ECIP Process
+	status: Final
+	type: Meta
+	discussions-to: https://github.com/ethereumclassic/ECIPs/issues/58
+	author: Wei Tang (@sorpaas)
+	created: 2017-06-29
+	license: Apache-2
 
 # Abstract
 


### PR DESCRIPTION
Changed preamble box to a shaded box (in markdown) because it was too wide when seen on Github and included a partial set of lines on ecips.ethereumclassic.org instead of all the lines of the preamble (pls check if it breaks or would be ok on the org site).

Changed status to `Final` from `Active` as the latter is not a formal status in the ecip process.