### PR TITLE
Correcting EIP -> ECIP typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ When you believe your ECIP is mature and ready to progress past the draft phase,
 * **Replaced** - When a Final ECIP is no longer relevant, its status may be changed to Replaced or Obsolete.
 * **Rejected** - Reasons for rejecting ECIPs include duplication of effort, disregard for formatting rules, unfocused or too broad, being technically unsound, not providing proper motivation, or obvious popular disapproval.
 * **Withdrawn** - ECIP authors may decide to change the status between Draft, Deferred, or Withdrawn. The ECIP editor may also change the status to Deferred if no progress is being made on the ECIP.
-* **Active** -- Some Informational and Process EIPs may also be moved to a status of “Active” instead of "Final" if they are never meant to be completed, e.g. [ECIP-1000](https://ecips.ethereumclassic.org/ECIPs/ecip-1000).
+* **Active** -- Some Informational and Process ECIPs may also be moved to a status of “Active” instead of "Final" if they are never meant to be completed, e.g. [ECIP-1000](https://ecips.ethereumclassic.org/ECIPs/ecip-1000).
 
 ## ECIP List
 


### PR DESCRIPTION
Corrected EIP to ECIP under `Active` status term.