### PR TITLE
Adjusting ECIP types to the ECIP site format

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -22,7 +22,7 @@ Because the ECIPs are maintained as text files in a versioned repository, their 
 
 This ECIP is licensed Apache-2, originally by [Luke Dashjr](https://github.com/luke-jr) under BSD 2-clause license.
 
-# ECIP workflow
+# ECIP Workflow
 
 ## Introduction
 
@@ -102,7 +102,7 @@ ECIP editors are intended to fulfill administrative and editorial responsibiliti
 * Merge the pull request when it is ready.
 * List the ECIP in [[README.mediawiki]]
 
-# ECIP format and structure
+# ECIP Format and Structure
 
 ## Specification
 
@@ -119,7 +119,7 @@ Each ECIP should have the following parts:
 - **Backwards compatibility** -- All ECIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The ECIP must explain how the author proposes to deal with these incompatibilities.
 - **Reference implementation** -- The reference implementation must be completed before any ECIP is given **"Final"** status, but it need not be completed before the ECIP is **"Accepted"**. It is better to finish the specification and rationale first and reach consensus on it before writing code. The final implementation must include test code and documentation appropriate for the Ethereum Classic protocol.
 
-### ECIP header preamble
+### ECIP Header Preamble
 
 Each ECIP must begin with an RFC 822 style header preamble. The headers must appear in the following order. Headers marked with "*" are optional and are described below. All other headers are required.
 
@@ -176,11 +176,11 @@ There are three types of ECIP:
 
 It is highly recommended that a single ECIP contain a single key proposal or new idea. The more focused the ECIP, the more successful it tends to be. A change to one client doesn't require an ECIP; a change that affects multiple clients, or defines a standard for multiple apps to use, does.
 
-An ECIP must meet certain minimum criteria. It must be a clear and complete description of the proposed enhancement. The enhancement must represent a net improvement. The proposed implementation, if applicable, must be solid and must not complicate the protocol unduly.
+An ECIP must meet certain minimum criteria. It must be a clear and complete description of the proposed enhancement. The enhancement must represent a net improvement.
 
-# ECIP status field
+## ECIP Status Field
 
-## Specification
+### Specification
 
 The typical paths of the status of ECIPs are as follows:
 
@@ -233,9 +233,9 @@ These criteria are considered objective ways to observe the de facto adoption of
 
 - The ECIP process exists for standardisation between independent projects. If something only affects one project, it should be done through that project's own internal processes, and never be proposed as a ECIP in the first place.
 
-# ECIP comments
+## ECIP comments
 
-## Specification
+### Specification
 
 Each ECIP should, in its preamble, link to a public wiki page with a summary tone of the comments on that page.
 
@@ -289,7 +289,7 @@ To avoid doubt: comments and status are unrelated metrics to judge an ECIP, and 
 
 - Participants should freely refrain from commenting outside of their area of knowledge or expertise. However, comments should not be censored, and participation should be open to the public.
 
-## ECIP licensing
+## ECIP Licensing
 
 ### Specification
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -162,13 +162,21 @@ ECIPs may also have a `Superseded-By` header indicating that a ECIP has been ren
 
 ECIPs may include auxiliary files such as diagrams. If if requires images, the image files should be included in a subdirectory of the `assets` folder for that ECIP as follow: `assets/ecip-X`. When linking to an image in the ECIP, use the related links such as `./assets/ecip-X/image.png`.
 
-# ECIP types
+## ECIP Types
 
-There are three kinds of ECIP:
+There are three types of ECIP:
 
-- **A Standards Track ECIP** describes any change that affects most or all Ethereum Classic implementations, such as a change to the network protocol, a change in block or transaction validity rules, or any change or addition that affects the interoperability of applications using Ethereum Classic. Standards Track ECIPs consist of two parts, a design document and a reference implementation.
-- **An Informational ECIP** describes a Ethereum Classic design issue, or provides general guidelines or information to the Ethereum Classic community, but does not propose a new feature. Informational ECIPs do not necessarily represent a Ethereum Classic community consensus or recommendation, so users and implementors are free to ignore Informational ECIPs or follow their advice.
-- **A Process ECIP** describes a process surrounding Ethereum Classic, or proposes a change to (or an event in) a process. Process ECIPs are like Standards Track ECIPs but apply to areas other than the Ethereum Classic protocol itself. They may propose an implementation, but not to Ethereum Classic's codebase; they often require community consensus; unlike Informational ECIPs, they are more than recommendations, and users are typically not free to ignore them. Examples include procedures, guidelines, changes to the decision-making process, and changes to the tools or environment used in Ethereum Classic development. Any meta-ECIP is also considered a Process ECIP.
+- A **Standard Track ECIP** describes any change that affects most or all Ethereum Classic implementations, such as a change to the network protocol, a change in block or transaction validity rules, proposed application standards/conventions, or any change or addition that affects the interoperability of applications using Ethereum Classic. Furthermore, Standard Track ECIPs can be broken down into the following categories:
+  - **Core** - improvements requiring a consensus fork, as well as changes that are not necessarily consensus critical but may be relevant to core developer discussions.
+  - **Networking** - improvements to networking protocol specifications.
+  - **Interface** - improvements around client [API/RPC] specifications and standards, and also certain language-level standards like method names  and contract ABIs.
+  - **ECBP (Ethereum Classic Best Practice)** - application-level standards and conventions, including contract standards such as token standards, name registries, URI schemes, library/package formats, and wallet formats.
+- A **Meta ECIP** describes a **process** surrounding Ethereum Classic or proposes a change to (or an event in) a process. Process ECIPs are like Standard Track ECIPs, but apply to areas other than the Ethereum Classic protocol itself. They may propose an implementation, but not to Ethereum Classic's codebase; they often require community consensus; unlike Informational ECIPs, they are more than recommendations, and users are typically not free to ignore them. Examples include procedures, guidelines, changes to the decision-making process (e.g. this ECIP-1000 process document), and changes to the tools or environment used in Ethereum Classic development. *Any meta-ECIP is also considered a Process ECIP.*
+- An **Informational ECIP** describes an Ethereum Classic design issue, or provides general guidelines or information to the Ethereum Classic community, but does not propose a new feature. Informational ECIPs do not necessarily represent Ethereum Classic community consensus or a recommendation, so users and implementors are free to ignore Informational ECIPs or follow their advice.
+
+It is highly recommended that a single ECIP contain a single key proposal or new idea. The more focused the ECIP, the more successful it tends to be. A change to one client doesn't require an ECIP; a change that affects multiple clients, or defines a standard for multiple apps to use, does.
+
+An ECIP must meet certain minimum criteria. It must be a clear and complete description of the proposed enhancement. The enhancement must represent a net improvement. The proposed implementation, if applicable, must be solid and must not complicate the protocol unduly.
 
 # ECIP status field
 
@@ -189,6 +197,10 @@ ECIPs should be changed from `Draft` or `Last Call` status, to `Rejected`, upon 
 An `Accepted` ECIP may progress to `Final` only when specific criteria reflecting real-world adoption has occurred. This is different for each ECIP depending on the nature of its proposed changes, which will be expanded on below. Evaluation of this status change should be **objectively verifiable**, and/or be discussed on the development calls, Discord channel, other groups or the mailing list.
 
 When a `Final` ECIP is no longer relevant, its status may be changed to `Replaced`. This change must also be **objectively verifiable** and/or discussed.
+
+Some Informational ECIPs, which are considered process ECIPs, may also be moved to a status of `Active` instead of `Final` if they are never meant to be completed, e.g. this [ECIP-1000.](./ecip-1000.md)
+
+`Draft` ECIPs which may be in a very early stage may be entered as `WIP` ECIPs, which means they are a work in progress.
 
 A process ECIP may change status from `Draft` to `Final` when it achieves rough consensus on the discussion process. Such a proposal is said to have rough consensus if it has been open to discussion on the development calls, Discord channel, other groups or the mailing list for at least one month, and no person maintains any unaddressed substantiated objections to it. Addressed or obstructive objections may be ignored/overruled by general agreement that they have been sufficiently addressed, but clear reasoning must be given in such circumstances.
 


### PR DESCRIPTION
To adjust to the new ecips.ethereumclassic.org website:

I changed the old ECIP types which were "Standard Track", "Process" and "Informational" to the new ones which are:

• Standard Track
   -- Core
   -- Networking
   -- Interface
   -- ECBP (analogous to "ERC" in Ethereum)
• Meta
• Informational

I also added status terms `WIP` and `Active` to adjust them to our ECIP status reality, e.g. ECIP-1000 is `Active`.