### PR TITLE
Change status to final

### DIFF
--- a/_specs/ecip-1054.md
+++ b/_specs/ecip-1054.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1054
 title: Atlantis EVM and Protocol Upgrades
-status: Accepted
+status: Final
 type: Meta
 author: Isaac Ardis <isaac.a@etclabs.org>
 created: 2019-02-11


### PR DESCRIPTION
Given Atlantis hard fork is executed, this PR is changing the status of ECIP-1054 to `final` according to the process on ECIP-1000.