### PR TITLE
Correct 'St. Petersburg' on ecip-1056.md

### DIFF
--- a/_specs/ecip-1056.md
+++ b/_specs/ecip-1056.md
@@ -11,13 +11,13 @@ created: 2019-03-25
 
 ### Simple Summary
 
-Enable the outstanding Ethereum Foundation _Constaninople_ and _Petersburg_ network protocol upgrades on the Ethereum
+Enable the outstanding Ethereum Foundation _Constaninople_ and _St. Petersburg_ network protocol upgrades on the Ethereum
 Classic network in a hard-fork code-named _Agharta_ to enable maximum compatibility across these networks.
 
 ### Abstract
 
 Add support for a subset of protocol-impacting changes introduced in the Ethereum Foundation (ETH) network via the
-_Constaninople_ and _Petersburg_ hardforks. The proposed changes for Ethereum Classic's _Agharta_ upgrade include:
+_Constaninople_ and _St. Petersburg_ hardforks. The proposed changes for Ethereum Classic's _Agharta_ upgrade include:
 
 - Constantinople bitwise shifting instructions
 - Constantinople skinny `CREATE2` opcode
@@ -53,7 +53,7 @@ Specifically with definition from EIP-1702 "Usage Template" section:
 
 ### Rationale
 
-__Atomicity__: This protocol specification notably merges the scheduled features of the anticipated _Petersburg_
+__Atomicity__: This protocol specification notably merges the scheduled features of the anticipated _St. Petersburg_
 protocol upgrade, which would removes the buggy proposal `SSTORE` net-gas metering.
 
 __Interoperability__: Establishing and maintaining interoperable behavior between Ethereum clients is essential for
@@ -69,7 +69,7 @@ increases its functionality and should be considered a feature upgrade rather th
 
 Adoption of the content of this ECIP requires a hard fork as it introduces changes that are not backward compatible.
 
-The following clients with Ethereum Classic support implement the _Constaninople_ and _Petersburg_ features currently:
+The following clients with Ethereum Classic support implement the _Constaninople_ and _St. Petersburg_ features currently:
 
 - Geth Classic: no support
 - Parity Ethereum: all features due to Ethereum Foundation compatibility


### PR DESCRIPTION
Correcting from _Petersburg_ to _St. Petersburg_.