### PR TITLE
Adding Discussion-to link to ECIP-1043

### DIFF
--- a/_specs/ecip-1043.md
+++ b/_specs/ecip-1043.md
@@ -6,6 +6,7 @@ author: Cody Burns <cody.w.burns@gmail.com>
 status: Draft
 type: Standard
 category: Core
+Discussions-to: https://github.com/ethereumclassic/ECIPs/issues/138
 created: 2018-04-16
 ---
 


### PR DESCRIPTION
Adding Discussion-to link to ECIP-1043 about fixing DAG: https://github.com/ethereumclassic/ECIPs/issues/138