### PR TITLE
ECIP-1066: Active Ethereum Classic Network Description

### DIFF
--- a/_specs/ecip-1066.md
+++ b/_specs/ecip-1066.md
@@ -1,0 +1,24 @@
+---
+lang: en
+ecip: 1066
+title: Ethereum Classic Network Description
+status: Active
+type: Meta
+author: Wei Tang (@sorpaas)
+created: 2019-10-07
+---
+
+This document records feature upgrades that have been applied in
+Ethereum Classic network mainnet.
+
+|--------------|---------------------------------------------------------------|
+| Block Number | Specification                                                 |
+|--------------|---------------------------------------------------------------|
+| 0            | [EIP-684](https://github.com/ethereum/EIPs/issues/684)        |
+| 1,150,000    | [EIP-606](https://eips.ethereum.org/EIPS/eip-606)             |
+| 2,500,000    | [ECIP-1015](http://ecips.ethereumclassic.org/ECIPs/ecip-1015) |
+| 3,000,000    | [ECIP-1010](http://ecips.ethereumclassic.org/ECIPs/ecip-1010) |
+| 5,000,000    | [ECIP-1017](http://ecips.ethereumclassic.org/ECIPs/ecip-1017) |
+| 5,000,000    | [ECIP-1039](http://ecips.ethereumclassic.org/ECIPs/ecip-1039) |
+| 5,900,000    | [ECIP-1041](http://ecips.ethereumclassic.org/ECIPs/ecip-1041) |
+| 8,772,000    | [ECIP-1054](http://ecips.ethereumclassic.org/ECIPs/ecip-1054) |

--- a/_specs/ecip-1066.md
+++ b/_specs/ecip-1066.md
@@ -11,9 +11,8 @@ created: 2019-10-07
 This document records feature upgrades that have been applied in
 Ethereum Classic network mainnet.
 
-|--------------|----------------------------------------------------------------|
 | Block Number | Specification                                                  |
-|--------------|----------------------------------------------------------------|
+| ------------ | -------------------------------------------------------------- |
 | 0            | [EIP-684](https://github.com/ethereum/EIPs/issues/684)         |
 | 1,150,000    | [EIP-606](https://eips.ethereum.org/EIPS/eip-606)              |
 | 2,500,000    | [ECIP-1015](https://ecips.ethereumclassic.org/ECIPs/ecip-1015) |

--- a/_specs/ecip-1066.md
+++ b/_specs/ecip-1066.md
@@ -11,14 +11,15 @@ created: 2019-10-07
 This document records feature upgrades that have been applied in
 Ethereum Classic network mainnet.
 
-|--------------|---------------------------------------------------------------|
-| Block Number | Specification                                                 |
-|--------------|---------------------------------------------------------------|
-| 0            | [EIP-684](https://github.com/ethereum/EIPs/issues/684)        |
-| 1,150,000    | [EIP-606](https://eips.ethereum.org/EIPS/eip-606)             |
-| 2,500,000    | [ECIP-1015](http://ecips.ethereumclassic.org/ECIPs/ecip-1015) |
-| 3,000,000    | [ECIP-1010](http://ecips.ethereumclassic.org/ECIPs/ecip-1010) |
-| 5,000,000    | [ECIP-1017](http://ecips.ethereumclassic.org/ECIPs/ecip-1017) |
-| 5,000,000    | [ECIP-1039](http://ecips.ethereumclassic.org/ECIPs/ecip-1039) |
-| 5,900,000    | [ECIP-1041](http://ecips.ethereumclassic.org/ECIPs/ecip-1041) |
-| 8,772,000    | [ECIP-1054](http://ecips.ethereumclassic.org/ECIPs/ecip-1054) |
+|--------------|----------------------------------------------------------------|
+| Block Number | Specification                                                  |
+|--------------|----------------------------------------------------------------|
+| 0            | [EIP-684](https://github.com/ethereum/EIPs/issues/684)         |
+| 1,150,000    | [EIP-606](https://eips.ethereum.org/EIPS/eip-606)              |
+| 2,500,000    | [ECIP-1015](https://ecips.ethereumclassic.org/ECIPs/ecip-1015) |
+| 3,000,000    | [ECIP-1010](https://ecips.ethereumclassic.org/ECIPs/ecip-1010) |
+| 3,000,000    | [EIP-160](https://eips.ethereum.org/EIPS/eip-160)              |
+| 5,000,000    | [ECIP-1017](https://ecips.ethereumclassic.org/ECIPs/ecip-1017) |
+| 5,000,000    | [ECIP-1039](https://ecips.ethereumclassic.org/ECIPs/ecip-1039) |
+| 5,900,000    | [ECIP-1041](https://ecips.ethereumclassic.org/ECIPs/ecip-1041) |
+| 8,772,000    | [ECIP-1054](https://ecips.ethereumclassic.org/ECIPs/ecip-1054) |


### PR DESCRIPTION
This creates an ECIP for the current active network description of Ethereum Classic mainnet. This will be the second ECIP document with the "active" status along with ECIP-1000.