### PR TITLE
fix: Make Last Call consistent

### DIFF
--- a/_data/statuses.yaml
+++ b/_data/statuses.yaml
@@ -1,6 +1,6 @@
 - WIP
 - Draft
-- Last call
+- Last Call
 - Accepted
 - Final
 - Deferred


### PR DESCRIPTION
Last Call doesn't show up on our website even if some ECIPs have Last Calls. @TokenHash pointed me to the statuses.yml and I noticed the status for it is called "Last call" when everywhere else it is "Last Call".

Even on Ethereum EIP, it's called "Last Call" on the same file: https://github.com/ethereum/EIPs/blob/master/_data/statuses.yaml#L1

I think this is why when it parses that status, it doesn't display it as "Last call" is a different string than "Last Call".

Haven't tested it, figured I'd get this fix in a PR and we can all discuss if necessary.