### PR TITLE
Rename Aztlán as Asgard

### DIFF
--- a/_specs/ecip-1061.md
+++ b/_specs/ecip-1061.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 ecip: 1061
-title: Aztlán EVM and Protocol Upgrades
+title: Asgard EVM and Protocol Upgrades
 status: Draft
 type: Meta
 author: Talha Cross (@soc1c)
@@ -12,12 +12,12 @@ discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
 ### Simple Summary
 
 Enable the outstanding Ethereum Foundation _Istanbul_ network protocol upgrades on the Ethereum
-Classic network in a hard-fork code-named _Aztlán_ to enable maximum compatibility across these networks.
+Classic network in a hard-fork code-named _Asgard_ to enable maximum compatibility across these networks.
 
 ### Abstract
 
 Add support for a subset of protocol-impacting changes introduced in the Ethereum Foundation (ETH) network via the
-_Istanbul_ hardforks. The proposed changes for Ethereum Classic's _Aztlán_ upgrade include:
+_Istanbul_ hardforks. The proposed changes for Ethereum Classic's _Asgard_ upgrade include:
 
 - TBD
 


### PR DESCRIPTION
Rename Aztlán as Asgard, which is a better known fictional place, easier to remember and has no ambiguity of spelling.

Twitter poll:
https://twitter.com/BobSummerwill/status/1188479134533484545