### PR TITLE
Defined a new IP protection process for ECIPs.

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -293,64 +293,137 @@ To avoid doubt: comments and status are unrelated metrics to judge an ECIP, and 
 
 ### Specification
 
-New ECIPs may be accepted with the following licenses. Each new ECIP must identify at least one acceptable license in its preamble. The License header in the preamble must be placed after the Created header. Each license must be referenced by their respective abbreviation given below.
+All new ECIPs should use Apache 2.0 or newer licensing for the specification and
+may use Apache 2.0+ or various other copyleft licenses for any associated
+example source code.  Earlier versions of ECIP-1000 allowed a wider
+range of licenses, but that left loopholes for IP attacks on ETC.
 
-For example, a preamble might include the following License header:
+The preamble for all new ECIPs should look like this one of these two options:
 
-    License: BSD-2-Clause
-             GNU-All-Permissive
+    License: Apache-2.0
+    License: Apache-2.0+
 
-In this case, the ECIP text is fully licensed under both the OSI-approved BSD 2-clause license as well as the GNU All-Permissive License, and anyone may modify and redistribute the text provided they comply with the terms of *either* license. In other words, the license list is an "OR choice", not an "AND also" requirement.
 
-It is also possible to license source code differently from the ECIP text. A optional License-Code header is placed after the License header. Again, each license must be referenced by their respective abbreviation given below.
+### Why Apache 2.0?
+
+There are numerous permissive software licenses which are
+[OSI approved](https://opensource.org/licenses/alphabetical),
+with a much shorter list of
+[popular ones](https://opensource.org/licenses) (really boiling down
+to MIT, BSD and Apache).  So why mandate Apache 2.0 or newer?
+
+It essentially boils down to compatibility with GPLv3 in combination with protection
+from potential software patent trolling and other IP attacks.
+
+Apache 2.0 is the Free Software Foundation’s own recommendation for
+permissive licences for that very reason:
+
+"This is a free software license, compatible with version 3 of the GNU GPL."
+
+"Please note that this license is not compatible with GPL version 2, because it has some requirements that are not in that GPL version. These include certain patent termination and indemnification provisions. The patent termination provision is a good thing, which is why we recommend the Apache 2.0 license for substantial programs over other lax permissive licenses."
+
+[Various Licenses and Comments about them, Free Software Foundation](https://www.gnu.org/licenses/license-list.html#apache2)
+
+There is a good description of [license compatibility](https://en.wikipedia.org/wiki/License_compatibility) on Wikipedia.
+
+
+### Optional alternative licensing for example source code
+
+Any example code source code associated with an ECIP should ideally be licensed as Apache 2.0 or
+newer in the same way as the specification, or can optionally be licensed under various copyleft
+alternative licenses.
+
+Each license must be referenced by their respective abbreviation given below.
 
 For example, a preamble specifying the optional License-Code header might look like:
 
-    License: BSD-2-Clause
-             GNU-All-Permissive
-    License-Code: GPL-2.0+
+    License: Apache-2.0
+    License-Code: GPL-3.0+
 
-In this case, the code in the ECIP is not available under the BSD or All-Permissive licenses, but only under the terms of the GNU General Public License (GPL), version 2 or newer.
-If the code were to be available under *only* version 2 exactly, the "+" symbol should be removed from the license abbreviation.
-For a later version (eg, GPL 3.0), you would increase the version number (and retain or remove the "+" depending on intent).
+In this case, the code in the ECIP is not available under the Apache 2.0,
+license but only under the terms of the GNU General Public License (GPL), version 3 or newer.
+If the code were to be available under *only* version 3 exactly, the "+" symbol should
+be removed from the license abbreviation.
 
-    License-Code: GPL-2.0   # This refers to GPL v2.0 *only*, no later license versions are acceptable.
-    License-Code: GPL-2.0+  # This refers to GPL v2.0 *or later*.
     License-Code: GPL-3.0   # This refers to GPL v3.0 *only*, no later license versions are acceptable.
     License-Code: GPL-3.0+  # This refers to GPL v3.0 *or later*.
 
 In the event that the licensing for the text or code is too complicated to express with a simple list of alternatives, the list should instead be replaced with the single term "Complex". In all cases, details of the licensing terms must be provided in the Copyright section of the ECIP.
 
-ECIPs are not required to be *exclusively* licensed under approved terms, and may also be licensed under unacceptable licenses *in addition to* at least one acceptable license.
-In this case, only the acceptable license(s) should be listed in the License and License-Code headers.
 
-### Recommended licenses
+### Preamble codes for acceptable licenses
 
-* Apache-2.0: [Apache License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-* BSD-2-Clause: [OSI-approved BSD 2-clause license](https://opensource.org/licenses/BSD-2-Clause)
-* BSD-3-Clause: [OSI-approved BSD 3-clause license](https://opensource.org/licenses/BSD-3-Clause)
-* CC0-1.0: [Creative Commons CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
-* GNU-All-Permissive: [GNU All-Permissive License](http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
+* AGPL-3.0+: [GNU Affero General Public License (AGPL), version 3 or newer](https://opensource.org/licenses/AGPL-3.0)
+* Apache-2.0+: [Apache License, version 2 or newer](https://opensource.org/licenses/Apache-2.0)
+* GPL-3.0+: [GNU General Public License (GPL), version 3 or newer](https://opensource.org/licenses/gpl-3.0)
+* LGPL-3.0+: [GNU Lesser General Public License (LGPL), version 2 or newer](https://opensource.org/licenses/lgpl-3.0)
+* MPL-2.0+: [Mozilla Public License (LGPL), version 2 or newer](https://opensource.org/licenses/mpl-2.0)
 
-In addition, it is recommended that literal code included in the ECIP be dual-licensed under the same license terms as the project it modifies. For example, literal code intended for Ethereum Classic Core would ideally be dual-licensed under the MIT license terms as well as one of the above with the rest of the ECIP text.
 
-### Not recommended, but acceptable licenses
+## Developer Certificate of Origin (DCO)
 
-* BSL-1.0: [Boost Software License, version 1.0](http://www.boost.org/LICENSE_1_0.txt)
-* CC-BY-4.0: [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
-* CC-BY-SA-4.0: [Creative Commons Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)
-* MIT: [Expat/MIT/X11 license](https://opensource.org/licenses/MIT)
-* AGPL-3.0+: [GNU Affero General Public License (AGPL), version 3 or newer](http://www.gnu.org/licenses/agpl-3.0.en.html)
-* FDL-1.3: [GNU Free Documentation License, version 1.3](http://www.gnu.org/licenses/fdl-1.3.en.html)
-* GPL-2.0+: [GNU General Public License (GPL), version 2 or newer](http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
-* LGPL-2.1+: [GNU Lesser General Public License (LGPL), version 2.1 or newer](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+All new ECIPs should include a [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) sign-off.
 
-## Rationale
+The sign off needs to be using your legal name, not a pseudonym. Git has a built-in mechanism to allow this with the -s or --signoff argument to git commit command, providing your user.name and user.email have been setup correctly.
 
-**Why are there software licenses included?**
+A DCO is a simple affirmation that the source code being submitted originated from the developer, or
+that the developer has permission to submit the code.  DCOs are the primary defence for open source
+projects against patent trolling or other IP attacks.
 
-* Some ECIPs, especially consensus layer, may include literal code in the ECIP itself which may not be available under the exact license terms of the ECIP.
-* Despite this, not all software licenses would be acceptable for content included in ECIPs.
+DCOs were introduced for all contributions to the Linux Kernel in 2004
+following the [SCO-Linux disputes](https://en.wikipedia.org/wiki/SCO%E2%80%93Linux_disputes).
+
+DCO with real-name sign-off is the mandatory IP protection bar for all
+[Hyperledger](https://hyperledger.org) projects, based on decades of
+practical experience on such matters at the Linux Foundation across
+their [raft of collaboration projects](https://www.linuxfoundation.org/projects/).
+
+This IP protection was added to the ECIP process in November 2019,
+when our [experience with ProgPOW](https://bobsummerwill.com/2019/09/17/progpow-author-kristy-leigh-minehan-uninvited-from-etc-summit/)
+exposed the complete lack of appropriate IP protection within the EIP process, and
+some loopholes within the existing ETC process due to lack of DCOs.
+
+
+## But isn't ETC about permissionless and privacy?
+
+For users of the platform, absolutely, but the process for every
+open source project on the planet is and always has been permissioned.
+
+No individual has an *unconditional* right to inclusion within any
+particular ecosystem.  Reputation does matter.  You cannot "Code Audit"
+your way through a situation where a predator is socially attacking your
+project.  Exclusion of bad actors is essential to the health of your
+ecosystem.  ETC's social layer is very strong, but systemic defenses
+are also very important.
+
+Rick Falkvinge "Psychopath Code: Let's talk about predators"
+https://www.youtube.com/watch?v=Zkg_-_HwRcI
+
+No individual has an *unconditional* right to expect their contributions
+to be accepted by any project.  All open source projects define a set
+of maintainers, who are the gatekeeper who maintain the quality bar
+using a permissioning system.  For the ECIP process those gatekeepers
+are the ECIP editors.  All proposals must be well-formed and must
+meet the requirements defined in this ECIP.  Anonymous contributors
+do not have the same risk profile as known individuals.  Many
+incredibly valuable contributions have been made to open source
+projects by anonymous individuals, but they do need to be treated with
+a different risk assessment framework.
+
+At the time of adoption of this stronger IP policy there were no accepted
+EIPs or ECIPs proposed by anonymous individuals for either ETH or ETC,
+in the lifetime of both projects.  ProgPOW will be the very first
+instance of that, if it is accepted into ETH as appears likely.
+
+
+## What if some incredibly valuable ECIP is proposed by an anon?
+
+The ECIP editors can choose to "bless something through" without the
+real name requirement, but they are putting their own reputations
+on the line by doing so.  Pressing that "override button" may be a
+serious risk in most cases, but we retain that optional for exceptional
+situations.
+
 
 # See Also
 


### PR DESCRIPTION
Defined a new IP protection process for ECIPs.
Mandatory use of Apache 2.0 for ECIPs, plus optional use of various copyleft license for the source code.
Mandatory DCOs for contributions with real name requirement.
Option for ECIP editors to override the real name requirement if they feel a contribution is exceptional.