### PR TITLE
Moving to Withdrawn Status

### DIFF
--- a/_specs/ecip-1016.md
+++ b/_specs/ecip-1016.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1016
 title: ETC Improvement Proposal Management
-status: Draft
+status: Withdrawn
 type: Meta
 author: Cody W Burns <Cody.w.burns@ethereumclassic.com>
 created: 2016-10-25


### PR DESCRIPTION
With author consent, moving this ECIP to withdrawn as its contents are largely included and covered in ECIP-1000.