### PR TITLE
ECIP-1040, ECIP-1068 and ECIP-1069: Account Versioning ECIPs and Extensions

### DIFF
--- a/_specs/ecip-1040.md
+++ b/_specs/ecip-1040.md
@@ -8,6 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2017-12-30
+license: Apache-2.0
 ---
 
 ## Simple Summary

--- a/_specs/ecip-1040.md
+++ b/_specs/ecip-1040.md
@@ -1,0 +1,238 @@
+---
+lang: en
+ecip: 1040
+title: Generalized Account Versioning Scheme
+author: Wei Tang (@sorpaas)
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/169
+status: Draft
+type: Standards Track
+category: Core
+created: 2017-12-30
+---
+
+## Simple Summary
+
+Introduce account versioning for smart contracts so upgrading the VM
+or introducing new VMs can be easier.
+
+## Abstract
+
+This defines a method of hard forking while maintaining the exact
+functionality of existing account by allowing multiple versions of the
+virtual machines to execute in the same block. This is also useful to
+define future account state structures when we introduce the on-chain
+WebAssembly virtual machine.
+
+## Motivation
+
+By allowing account versioning, we can execute different virtual
+machine for contracts created at different times. This allows breaking
+features to be implemented while making sure existing contracts work
+as expected.
+
+Note that this specification might not apply to all hard forks. We
+have emergency hard forks in the past due to network attacks. Whether
+they should maintain existing account compatibility should be
+evaluated in individual basis. If the attack can only be executed once
+against some particular contracts, then the scheme defined here might
+still be applicable. Otherwise, having a plain emergency hard fork
+might still be a good idea.
+
+## Specification
+
+### Account State
+
+Re-define account state stored in the world state trie to have 5
+items: `nonce`, `balance`, `storageRoot`, `codeHash`, and
+`version`. The newly added field `version` is a 256-bit **scalar**. We
+use the definition of "scalar" from Yellow Paper. Note that this is
+the same type as `nonce` and `balance`, and it is equivalent to a RLP
+variable-sized byte array with no leading zero, of maximum length 32.
+
+When `version` is zero, the account is RLP-encoded with the first 4
+items. When `version` is not zero, the account is RLP-encoded with 5
+items.
+
+Account versions can also optionally define additional account state
+RLP fields, whose meaning are specified through its `version`
+field. In those cases, the parsing strategy is defined in "Additional
+Fields in Account State RLP" section.
+
+### Contract Execution
+
+When fetching an account code from state, we always fetch the
+associated version field together. We refer to this as the *code's
+version* below. The code of the account is always executed in the
+*code's version*.
+
+In particular, this means that for `DELEGATECALL` and `CALLCODE`, the
+version of the execution call frame is the same as
+delegating/receiving contract's version.
+
+### Contract Deployment
+
+In Ethereum, a contract has a deployment method, either by a contract
+creation transaction, or by another contract. If we regard this
+deployment method a contract's *parent*, then we find them forming a
+family of contracts, with the *root* being a contract creation
+transaction.
+
+We let a family of contracts to always have the same `version`. That
+is, `CREATE` and `CREATE2` will always deploy contract that has the
+same `version` as the *code's version*.
+
+In other words, `CREATE` and `CREATE2` will execute the init code
+using the current *code's version*, and deploy the contract of the
+current *code's version*. This holds even if the to-be-deployed code
+is empty.
+
+### Validation
+
+A new phrase, *validation* is added to contract deployment (by
+`CREATE` / `CREATE2` opcodes, or by contract creation
+transaction). When `version` is `0`, the phrase does nothing and
+always succeeds. Future VM versions can define additional validation
+that has to be passed.
+
+If the validation phrase fails, deployment does not proceed and return
+out-of-gas.
+
+### Contract Creation Transaction
+
+Define `LATEST_VERSION` in a hard fork to be the latest supported VM
+version. A contract creation transaction is always executed in
+`LATEST_VERSION` (which means the *code's version* is
+`LATEST_VERSION`), and deploys contracts of `LATEST_VERSION`. Before a
+contract creation transaction is executed, run *validation* on the
+contract creation code. If it does not pass, return out-of-gas.
+
+### Precompiled Contract and Externally-owned Address
+
+Precompiled contracts and externally-owned addresses do not have
+`version`. If a message-call transaction or `CALL` / `CALLCODE` /
+`STATICCALL` / `DELEGATECALL` touches a new externally-owned address
+or a non-existing precompiled contract address, it is always created
+with `version` field being `0`.
+
+### Additional Fields in Account State RLP
+
+In the future we may need to associate more information into an
+account, and we already have some EIP/ECIPs that define new additional
+fields in the account state RLP. In this section, we define the
+parsing strategy when additional fields are added.
+
+* Check the RLP list length, if it is 4, then set account version to
+  `0`, and do not parse any additional fields.
+* If the RLP list length more than 4, set the account version to the
+  scalar at position `4` (counting from `0`).
+  * Check version specification for the number of additional fields
+    defined `N`, if the RLP list length is not equal to `5 + N`,
+    return parse error.
+  * Parse RLP position `5` to `4 + N` as the meaning specified in
+    additional fields.
+  
+## Extensions
+
+In relation to the above "Specification" section, we have defined the
+base account versioning layer. The base account versioning layer is
+already useful by itself and can handle most EVM improvements. Below
+we define two specifications that can be deployed separately, which
+improves functionality of base layer account versioning.
+
+Note that this section is provided only for documentation
+purpose. When "enabling ECIP-1040", those extensions should not be
+enabled unless the extension EIP is also included.
+
+- [ECIP-1068: Account Versioning Extension for Contract Creation
+  Transaction](./ecip-1068.md)
+- [ECIP-1069: Account Versioning Extension for CREATE and
+  CREATE2](./ecip-1069.md)
+
+## Usage Template
+
+This section defines how other ECIPs might use this account versioning
+ECIP. Note that currently we only define the usage template for base
+layer.
+
+Account versioning is usually applied directly to a hard fork meta
+ECIP. ECIPs in the hard fork are grouped by the virtual machine type,
+for example, EVM and eWASM. For each of them, we define:
+
+* **Version**: a non-zero scalar less than `2^256` that uniquely
+  identifies this version. Note that it does not need to be
+  sequential.
+* **Parent version**: the base that all new features derived
+  from. With parent version of `0` we define the base to be legacy
+  VM. Note that once a version other than `0` is defined, the legacy
+  VM's feature set must be frozen. When defining an entirely new VM
+  (such as eWASM), parent version does not apply.
+* **Features**: all additional features that are enabled upon this
+  version.
+
+If a meta ECIP includes ECIPs that provide additional account state RLP
+fields, we also define:
+
+* **Account fields**: all account fields up to the end of this meta
+  EIP, excluding the basic 5 fields (`nonce`, `balance`,
+  `storageRoot`, `codeHash` and `version`). If EIPs included that are
+  specific to modifying account fields do not modify VM execution
+  logic, it is recommended that we specify an additional version whose
+  execution logic is the same as previous version, but only the
+  account fields are changed.
+
+## Rationale
+
+This introduces account versioning via a new RLP item in account
+state. The design above gets account versioning by making the contract
+*family* always have the same version. In this way, versions are only
+needed to be provided by contract creation transaction, and there is
+no restrictions on formats of code for any version. If we want to
+support multiple newest VMs (for example, EVM and WebAssembly running
+together), then this will requires extensions such as ECIP-1068 and
+ECIP-1069.
+
+Alternatively, account versioning can also be done through:
+
+* **[26-VER](https://specs.that.world/26-ver/)** and
+  **[40-UNUSED](https://specs.that.world/40-unused/)**: This makes an
+  account's versioning soly dependent on its code header prefix. If
+  with only EIP-1707, it is not possible to certify any code is valid,
+  because current VM allows treating code as data. This can be fixed
+  by EIP-1712, but the drawback is that it's potentially backward
+  incompatible.
+* **EIP-1891**: Instead of writing version field into account RLP
+  state, we write it in a separate contract. This can accomplish the
+  same thing as this EIP and potentially reduces code complexity, but
+  the drawback is that every code execution will require an additional
+  trie traversal, which impacts performance.
+
+## Backwards Compatibility
+
+Account versioning is fully backwards compatible, and it does not
+change how current contracts are executed.
+
+## Discussions
+
+### Performance
+
+Currently nearly all full node implementations uses config parameters
+to decide which virtual machine version to use. Switching virtual
+machine version is simply an operation that changes a pointer using a
+different set of config parameters. As a result, this scheme has
+nearly zero impact to performance.
+
+### WebAssembly
+
+This scheme can also be helpful when we deploy on-chain WebAssembly
+virtual machine. In that case, WASM contracts and EVM contracts can
+co-exist and the execution boundary and interaction model are clearly
+defined as above.
+
+## Test Cases and Implementations
+
+To be added.
+
+## Copyright
+
+This work is licensed under [Apache License, Version
+2.0](http://www.apache.org/licenses/).

--- a/_specs/ecip-1068.md
+++ b/_specs/ecip-1068.md
@@ -9,6 +9,7 @@ type: Standards Track
 category: Core
 created: 2019-06-24
 requires: 1040
+license: Apache-2.0
 ---
 
 ## Simple Summary

--- a/_specs/ecip-1068.md
+++ b/_specs/ecip-1068.md
@@ -1,0 +1,71 @@
+---
+lang: en
+ecip: 1068
+title: Account Versioning Extension for Contract Creation Transaction
+author: Wei Tang (@sorpaas)
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/169
+status: Draft
+type: Standards Track
+category: Core
+created: 2019-06-24
+requires: 1040
+---
+
+## Simple Summary
+
+Specification for an extension of ECIP-1040 to allow contract creation
+transaction to create multiple versions.
+
+## Abstract
+
+This ECIP defines an extension to the base layer of account versioning
+(ECIP-1040) to allow multiple account versions to be used in contract
+creation transaction. Although this is not necessary at this moment,
+it will once we have multiple independent VMs (such as eWasm).
+
+## Motivation
+
+The base account versioning layer only allows contract of the
+newest version to be deployed via contract creation transaction. This
+is a reasonable assumption for current Ethereum network, because most
+of new features added to EVM are additions, and developers almost
+never want to deploy contracts that are not of the newest version. In
+this section, we provide an extension to allow multiple versions of
+contracts to be deployed via contract creation transaction.
+
+## Specification
+
+Add an additional field `version` (256-bit integer) in contract
+creation transaction. So it becomes `nonce`, `gasprice`, `startgas`,
+`to`, `value`, `data`, `v`, `r`, `s`, `version`. When signing or
+recovering, sign ten items, with `v`, `r`, `s` as defined by EIP-155.
+
+The transaction would be executed with the *code's version* in
+`version` supplied, and deploys contract of `version`. If `version` is
+not supported or *validation* does not pass, return out-of-gas.
+
+## Rationale
+
+By providing the additional field `version`, a contract creation
+transaction can specify which version it wants to deploy. In case of
+two independent VMs such as EVM and eWASM, we can allow two
+`LATEST_VERSION`s to be specified -- one for EVM and another for
+eWASM. Both of them then can deploy new contracts via transactions.
+
+## Backwards Compatibility
+
+This ECIP only changes transaction formats and does not change any VM
+execution logic, thus it has no backwards compatibility issue.
+
+## Test Cases
+
+Not yet provided.
+
+## Implementation
+
+Not yet implemented.
+
+## Copyright
+
+This work is licensed under [Apache License, Version
+2.0](http://www.apache.org/licenses/).

--- a/_specs/ecip-1069.md
+++ b/_specs/ecip-1069.md
@@ -9,6 +9,7 @@ type: Standards Track
 category: Core
 created: 2019-06-24
 requires: 1040
+license: Apache-2.0
 ---
 
 ## Simple Summary

--- a/_specs/ecip-1069.md
+++ b/_specs/ecip-1069.md
@@ -1,0 +1,77 @@
+---
+lang: en
+ecip: 1069
+title: Account Versioning Extension for CREATE and CREATE2
+author: Wei Tang (@sorpaas)
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/169
+status: Draft
+type: Standards Track
+category: Core
+created: 2019-06-24
+requires: 1040
+---
+
+## Simple Summary
+
+Specification for an extension of ECIP-1040 to allow an EVM contract to
+create multiple versions.
+
+## Abstract
+
+This ECIP defines an extension to the base layer of account versioning
+(ECIP-1040) to allow an EVM contract to create sub-contracts of
+multiple versions. Although this is not necessary at this moment, it
+will be a nice-to-have add-on.
+
+## Motivation
+
+The base account versioning layer only allows contracts of the same
+version to be deployed through `CREATE` and `CREATE2`. In this
+section, we provide an extension to allow different versions of
+contracts to be deployed via them, by providing two new opcodes,
+`VCREATE` and `VCREATE2`.
+
+## Specification
+
+Define two new opcodes `VCREATE` and `VCREATE2` at `0xf6` and `0xf7`
+respectively. `VCREATE` takes 4 stack arguments (version, value, input
+offset, input size), and `VCREATE2` takes 5 stack arguments (version,
+endowment, memory_start, memory_length, salt). Note that except the
+stack item `version`, other arguments are the same as `CREATE` and
+`CREATE2`.
+
+The two new opcodes behave identically to `CREATE` and `CREATE2`,
+except that it deploys contracts with version specified by stack item
+`version`.
+
+The network at all times maintains a constant list within the client
+of all deployable versions (which can be different from supported
+versions). Upon `VCREATE` and `VCREATE2`, if the specified `version`
+is not on the list of deployable versions, return out-of-gas.
+
+## Rationale
+
+By providing two additional opcodes `VCREATE` and `VCREATE2`, contract
+developers can deploy new contracts that take advantage of them to
+create new sub-contracts of multiple versions. This may be useful for
+situations like upgradable contracts (while it currently still can be
+done via proxy contacts using only base layer account versioning).
+
+## Backwards Compatibility
+
+This ECIP introduces two new opcodes for EVM runtime. Based on current
+assumed invariants, it should not have any noticeable backward
+compatibility issues.
+
+## Test Cases
+
+Not yet provided.
+
+## Implementation
+
+Not yet implemented.
+
+## Copyright
+
+This work is licensed under [Apache License, Version
+2.0](http://www.apache.org/licenses/).


### PR DESCRIPTION
This adds the following specifications to ECIPs repo:

* ECIP-1040: The base layer of account versioning. The current rough consensus.
* ECIP-1068: Extension of ECIP-1040 to allow transaction to deploy multiple versions.
* ECIP-1069: Extension of ECIP-1040 to allow CREATE/CREATE2 to deploy multiple versions.