### PR TITLE
ECIP-1000: Add MulanPSL into recommended licenses

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -331,6 +331,7 @@ In this case, only the acceptable license(s) should be listed in the License and
 * BSD-3-Clause: [OSI-approved BSD 3-clause license](https://opensource.org/licenses/BSD-3-Clause)
 * CC0-1.0: [Creative Commons CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
 * GNU-All-Permissive: [GNU All-Permissive License](http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
+* MulanPSL: [Mulan Permissive Software License，Version 1](https://license.coscl.org.cn/MulanPSL/)
 
 In addition, it is recommended that literal code included in the ECIP be dual-licensed under the same license terms as the project it modifies. For example, literal code intended for Ethereum Classic Core would ideally be dual-licensed under the MIT license terms as well as one of the above with the rest of the ECIP text.
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -331,7 +331,7 @@ In this case, only the acceptable license(s) should be listed in the License and
 * BSD-3-Clause: [OSI-approved BSD 3-clause license](https://opensource.org/licenses/BSD-3-Clause)
 * CC0-1.0: [Creative Commons CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
 * GNU-All-Permissive: [GNU All-Permissive License](http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
-* MulanPSL-1.0: [Mulan Permissive Software License，Version 1](https://license.coscl.org.cn/MulanPSL/)
+* MulanPSL-1.0: [Mulan Permissive Software License, Version 1](https://license.coscl.org.cn/MulanPSL/)
 
 In addition, it is recommended that literal code included in the ECIP be dual-licensed under the same license terms as the project it modifies. For example, literal code intended for Ethereum Classic Core would ideally be dual-licensed under the MIT license terms as well as one of the above with the rest of the ECIP text.
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -331,7 +331,7 @@ In this case, only the acceptable license(s) should be listed in the License and
 * BSD-3-Clause: [OSI-approved BSD 3-clause license](https://opensource.org/licenses/BSD-3-Clause)
 * CC0-1.0: [Creative Commons CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
 * GNU-All-Permissive: [GNU All-Permissive License](http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html)
-* MulanPSL: [Mulan Permissive Software License，Version 1](https://license.coscl.org.cn/MulanPSL/)
+* MulanPSL-1.0: [Mulan Permissive Software License，Version 1](https://license.coscl.org.cn/MulanPSL/)
 
 In addition, it is recommended that literal code included in the ECIP be dual-licensed under the same license terms as the project it modifies. For example, literal code intended for Ethereum Classic Core would ideally be dual-licensed under the MIT license terms as well as one of the above with the rest of the ECIP text.
 


### PR DESCRIPTION
This adds [MulanPSL](https://license.coscl.org.cn/MulanPSL/) into the "recommended license" section in ECIP-1000. From an initial look it fulfills most of the criteria we want for a specification license:

1. Explicit patent protection, similar to Apache-2.0.
2. Permissive.
3. It looks like some of the languages used in the license will make it work better in the Chinese jurisdiction, which some contributors might have preferences.