### PR TITLE
Proposing Coordinator Position

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -80,7 +80,7 @@ The current ECIP editors are:
 
 The current ECIP coordinators are:
 
-* Donald McIntyre (@TokenHash)
+* 
 
 ## Responsibilities & Workflow
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -68,7 +68,7 @@ A good reason to transfer ownership is because the original author no longer has
 
 **If you are interested in assuming ownership of a ECIP**, send a message asking to take over, addressed to both the original author and the ECIP editor. If the original author doesn't respond to email in a timely manner, the ECIP editor will make a unilateral decision (it's not like such decisions can't be reversed :).
 
-## ECIP Editors & Subeditors
+## ECIP Editors & Coordinators
 
 The current ECIP editors are:
 
@@ -78,11 +78,11 @@ The current ECIP editors are:
 * Afri Schoedon (@soc1c)
 * Yaz Khoury (@YazzyYaz)
 
-The current ECIP subeditors are:
+The current ECIP coordinators are:
 
 * Donald McIntyre (@TokenHash)
 
-## ECIP Editor & Subeditors Responsibilities & Workflow
+## Responsibilities & Workflow
 
 ### Introduction
 
@@ -106,7 +106,7 @@ ECIP editors are intended to fulfill administrative and editorial responsibiliti
 * Merge the pull request when it is ready.
 * List the ECIP in [[README.mediawiki]]
 
-ECIP subeditors are technical person or not, who check and correct the text and format of ECIPs also writing additions or deletions, specifically non-code non-software ECIPs, or copy improvement proposals from other improvement proposal repos, to help off-load work from, and assist editors in their duties and approving ECIPs.
+ECIP coordinators are technical person or not, who check and correct the text and format of ECIPs also writing additions or deletions, specifically non-code non-software ECIPs, or copy improvement proposals from other improvement proposal repos, to help off-load work from, and assist editors in their duties and approving ECIPs.
 
 # ECIP Format and Structure
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -68,7 +68,7 @@ A good reason to transfer ownership is because the original author no longer has
 
 **If you are interested in assuming ownership of a ECIP**, send a message asking to take over, addressed to both the original author and the ECIP editor. If the original author doesn't respond to email in a timely manner, the ECIP editor will make a unilateral decision (it's not like such decisions can't be reversed :).
 
-## ECIP Editors
+## ECIP Editors & Subeditors
 
 The current ECIP editors are:
 
@@ -78,7 +78,11 @@ The current ECIP editors are:
 * Afri Schoedon (@soc1c)
 * Yaz Khoury (@YazzyYaz)
 
-## ECIP Editor Responsibilities & Workflow
+The current ECIP subeditors are:
+
+* Donald McIntyre (@TokenHash)
+
+## ECIP Editor & Subeditors Responsibilities & Workflow
 
 ### Introduction
 
@@ -101,6 +105,8 @@ ECIP editors are intended to fulfill administrative and editorial responsibiliti
 * Assign a ECIP number in the pull request.
 * Merge the pull request when it is ready.
 * List the ECIP in [[README.mediawiki]]
+
+ECIP subeditors are technical person or not, who check and correct the text and format of ECIPs also writing additions or deletions, specifically non-code non-software ECIPs, or copy improvement proposals from other improvement proposal repos, to help off-load work from, and assist editors in their duties and approving ECIPs.
 
 # ECIP Format and Structure
 


### PR DESCRIPTION
I am proposing the "coordinator" position, a person, technical or not, who checks and corrects the text and format of ECIPs also writing additions or deletions, specifically non-code non-software ECIPs, or copies improvement proposals from other improvement proposal repos, to help off-load work from, and assist editors in correcting and approving such ECIPs. 

I am dropping myself as a candidate, but i recommend to add 2 person in the coordinator position if it is approved.