### PR TITLE
ECIP-1072, ECIP-1073, ECIP-1074: Backward Compatible Options for Istanbul Hard Forks

### DIFF
--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -7,6 +7,7 @@ type: Meta
 author: Wei Tang (@sorpaas)
 created: 2019-11-14
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
+license: Apache-2.0
 ---
 
 ### Simple Summary

--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -1,0 +1,79 @@
+---
+lang: en
+ecip: 1072
+title: Yingchun EVM and Protocol Upgrades
+status: Draft
+type: Meta
+author: Wei Tang (@sorpaas)
+created: 2019-11-14
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
+---
+
+### Simple Summary
+
+Enable the outstanding Ethereum Foundation _Istanbul_ network protocol
+upgrades on the Ethereum Classic network in a hard-fork code-named
+_Yingchun_ to enable maximum compatibility across these networks.
+
+In particular, delay EIP-1884 activation until backward compatibility
+solutions are in place on Ethereum Classic.
+
+### Abstract
+
+Add support for a subset of protocol-impacting changes introduced in
+the Ethereum Foundation (ETH) network via the _Istanbul_
+hardforks.
+
+This document proposes the following blocks at which to implement
+these changes in the Classic networks:
+
+- `TBD` on Mordor Classic PoW-testnet (Feb 5th, 2020)
+- `TBD` on Kotti Classic PoA-testnet (Feb 12th, 2020)
+- `TBD` on Ethereum Classic PoW-mainnet (March 25th, 2020)
+
+For more information on the opcodes and their respective EIPs and
+implementations, please see the _Specification_ section of this
+document.
+
+### Motivation
+
+To enhance the Ethereum Virtual Machine's (EVM) capabilities, various
+opcodes shall be added to the Ethereum Classic networks, all of which
+have been in use on the Ethereum Foundation networks since end of
+2019.
+
+This enables all EIPs in Istanbul, but EIP-1884, due to backward
+compatibility considerations.
+
+### Specification
+
+Enable the following EIPs at the hard fork block:
+
+- [EIP-152](https://eips.ethereum.org/EIPS/eip-152): Add Blake2
+  compression function `F` precompile
+- [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108): Reduce
+  alt_bn128 precompile gas costs
+- [EIP-1344](https://eips.ethereum.org/EIPS/eip-1344): Add ChainID
+  opcode
+- [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028): Calldata gas
+  cost reduction
+- [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200): Rebalance
+  net-metered SSTORE gas cost with consideration of SLOAD gas cost
+  change
+
+### Implementation
+
+Adoption of the content of this ECIP requires a hard fork as it
+introduces changes that are not backward compatible.
+
+The following clients with Ethereum Classic support implement the
+_Istanbul_ features currently:
+
+- Parity Ethereum
+- Multi-Geth
+- Hyperledger Besu
+
+## Copyright
+
+This work is licensed under [Apache License, Version
+2.0](http://www.apache.org/licenses/).

--- a/_specs/ecip-1073.md
+++ b/_specs/ecip-1073.md
@@ -7,6 +7,7 @@ type: Meta
 author: Wei Tang (@sorpaas)
 created: 2019-11-14
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
+license: Apache-2.0
 ---
 
 ### Simple Summary

--- a/_specs/ecip-1073.md
+++ b/_specs/ecip-1073.md
@@ -1,0 +1,86 @@
+---
+lang: en
+ecip: 1073
+title: Xichun EVM and Protocol Upgrades
+status: Draft
+type: Meta
+author: Wei Tang (@sorpaas)
+created: 2019-11-14
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
+---
+
+### Simple Summary
+
+Enable the outstanding Ethereum Foundation _Istanbul_ network protocol
+upgrades on the Ethereum Classic network in a hard-fork code-named
+_Xichun_ to enable maximum compatibility across these networks.
+
+In particular, enables account versioning EIP-1702.
+
+### Abstract
+
+Add support for a subset of protocol-impacting changes introduced in
+the Ethereum Foundation (ETH) network via the _Istanbul_ hardforks.
+
+This document proposes the following blocks at which to implement
+these changes in the Classic networks:
+
+- `TBD` on Mordor Classic PoW-testnet (Feb 5th, 2020)
+- `TBD` on Kotti Classic PoA-testnet (Feb 12th, 2020)
+- `TBD` on Ethereum Classic PoW-mainnet (March 25th, 2020)
+
+For more information on the opcodes and their respective EIPs and
+implementations, please see the _Specification_ section of this
+document.
+
+### Motivation
+
+To enhance the Ethereum Virtual Machine's (EVM) capabilities, various
+opcodes shall be added to the Ethereum Classic networks, all of which
+have been in use on the Ethereum Foundation networks since end of
+2019.
+
+This enables all Istanbul features, feature gated under ECIP-1702 /
+EIP-1702.
+
+### Specification
+
+Enable
+[ECIP-1040](https://ecips.ethereumclassic.org/ECIPs/ecip-1040). Freeze
+features on version `0`. Define a new account version `1`, with the
+following additional EIPs enabled:
+
+- [EIP-152](https://eips.ethereum.org/EIPS/eip-152): Add Blake2
+  compression function `F` precompile
+- [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108): Reduce
+  alt_bn128 precompile gas costs
+- [EIP-1344](https://eips.ethereum.org/EIPS/eip-1344): Add ChainID
+  opcode
+- [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884): Repricing for
+  trie-size-dependent opcodes
+- [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028): Calldata gas
+  cost reduction
+- [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200): Rebalance
+  net-metered SSTORE gas cost with consideration of SLOAD gas cost
+  change
+
+### Implementation
+
+Adoption of the content of this ECIP requires a hard fork as it
+introduces changes that are not backward compatible.
+
+The following clients with Ethereum Classic support implement the
+_Istanbul_ features and ECIP-1040 / EIP-1702 currently:
+
+- Parity Ethereum
+- Multi-Geth
+
+The following clients implement _Istanbul_ features but does not yet
+support ECIP-1040 / EIP-1702:
+
+- Hyperledger Besu
+
+## Copyright
+
+This work is licensed under [Apache License, Version
+2.0](http://www.apache.org/licenses/).

--- a/_specs/ecip-1074.md
+++ b/_specs/ecip-1074.md
@@ -7,6 +7,7 @@ type: Meta
 author: Wei Tang (@sorpaas)
 created: 2019-11-14
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
+license: Apache-2.0
 ---
 
 ### Simple Summary

--- a/_specs/ecip-1074.md
+++ b/_specs/ecip-1074.md
@@ -1,0 +1,96 @@
+---
+lang: en
+ecip: 1074
+title: Tanchun EVM and Protocol Upgrades
+status: Draft
+type: Meta
+author: Wei Tang (@sorpaas)
+created: 2019-11-14
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
+---
+
+### Simple Summary
+
+Enable the outstanding Ethereum Foundation _Istanbul_ network protocol
+upgrades on the Ethereum Classic network in a hard-fork code-named
+_Xichun_ to enable maximum compatibility across these networks.
+
+In particular, enables account versioning EIP-1702 with
+forward-compatible EVM changes.
+
+### Abstract
+
+Add support for a subset of protocol-impacting changes introduced in
+the Ethereum Foundation (ETH) network via the _Istanbul_ hardforks.
+
+This document proposes the following blocks at which to implement
+these changes in the Classic networks:
+
+- `TBD` on Mordor Classic PoW-testnet (Feb 5th, 2020)
+- `TBD` on Kotti Classic PoA-testnet (Feb 12th, 2020)
+- `TBD` on Ethereum Classic PoW-mainnet (March 25th, 2020)
+
+For more information on the opcodes and their respective EIPs and
+implementations, please see the _Specification_ section of this
+document.
+
+### Motivation
+
+To enhance the Ethereum Virtual Machine's (EVM) capabilities, various
+opcodes shall be added to the Ethereum Classic networks, all of which
+have been in use on the Ethereum Foundation networks since end of
+2019.
+
+This hard fork first enables the [Kunming hard fork
+specification](https://ecips.ethereumclassic.org/ECIPs/ecip-1065), and
+then enables all Istanbul features on top of the forward-compatible
+EVM.
+
+### Specification
+
+Enable
+[ECIP-1040](https://ecips.ethereumclassic.org/ECIPs/ecip-1040). Freeze
+features on version `0`. Define a new account version `1`, with the
+following additional EIPs enabled:
+
+- [39-UNGAS](https://specs.that.world/39-ungas/): Remove all
+  observable behavior of gas cost in EVM and change out-of-gas
+  exception to trap the whole transaction.
+- [40-UNUSED](https://specs.that.world/40-unused/): Disable deployment
+  of unused opcodes.
+- [EIP-152](https://eips.ethereum.org/EIPS/eip-152): Add Blake2
+  compression function `F` precompile
+- [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108): Reduce
+  alt_bn128 precompile gas costs
+- [EIP-1344](https://eips.ethereum.org/EIPS/eip-1344): Add ChainID
+  opcode
+- [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884): Repricing for
+  trie-size-dependent opcodes
+- [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028): Calldata gas
+  cost reduction
+- [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200): Rebalance
+  net-metered SSTORE gas cost with consideration of SLOAD gas cost
+  change
+
+### Implementation
+
+Adoption of the content of this ECIP requires a hard fork as it
+introduces changes that are not backward compatible.
+
+The following clients with Ethereum Classic support implement the
+_Istanbul_ features and ECIP-1040 / EIP-1702 currently:
+
+- Parity Ethereum
+- Multi-Geth
+
+The following clients implement _Istanbul_ features but does not yet
+support ECIP-1040 / EIP-1702:
+
+- Hyperledger Besu
+
+No clients currently have implemented *39-UNGAS* and *40-UNUSED* yet.
+
+## Copyright
+
+This work is licensed under [Apache License, Version
+2.0](http://www.apache.org/licenses/).

--- a/_specs/ecip-1074.md
+++ b/_specs/ecip-1074.md
@@ -13,7 +13,7 @@ discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
 
 Enable the outstanding Ethereum Foundation _Istanbul_ network protocol
 upgrades on the Ethereum Classic network in a hard-fork code-named
-_Xichun_ to enable maximum compatibility across these networks.
+_Tanchun_ to enable maximum compatibility across these networks.
 
 In particular, enables account versioning EIP-1702 with
 forward-compatible EVM changes.


### PR DESCRIPTION
This adds three new hard fork meta, with different options to apply the Istanbul upgrade in a backward compatible way:

* ECIP-1072: Apply Istanbul directly, but remove the offending EIP-1884.
* ECIP-1073: Apply Istanbul with account versioning ECIP-1040 / EIP-1702. Currently both Parity and Geth have the implementation required. However, the drawback, as discussed last time, is that this will require a new account version for every hard fork.
* ECIP-1074: Apply Istanbul with account versioning, and with forward-compatible EVM changes. Currently no client has implemented 39-UNGAS and 40-UNUSED yet, so this will require more work, and we will need to maintain our own ecosystem tools. However, it gives us a good future foundation for modifying EVMs further. This is basically combination of ECIP-1065 Kunming hard fork with Istanbul.