### PR TITLE
Update ECIP-1070 Status to Rejected

### DIFF
--- a/_specs/ecip-1070.md
+++ b/_specs/ecip-1070.md
@@ -3,7 +3,7 @@ ecip: 1070
 title: ProgPoW, a Programmatic Proof-of-Work, for Ethereum Classic
 author: Yaz Khoury <yaz@etccooperative.org>
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/172
-status: Draft
+status: Rejected
 type: Standards Track
 category: Core
 created: 2019-11-06


### PR DESCRIPTION
As per the Mining Call and Issue Link Summary: https://github.com/ethereumclassic/ECIPs/issues/174#issuecomment-557106181

Moving ECIP-1070: ProgPoW on ETC to Rejected Status with the agreement that someone who wants to champion this proposal can do so on a new ECIP in the future.