### PR TITLE
1000: demote wei tang from ecip editor status

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -72,7 +72,6 @@ A good reason to transfer ownership is because the original author no longer has
 
 The current ECIP editors are:
 
-* Wei Tang (@sorpaas)
 * Isaac Ardis (@meowsbits)
 * Cody Burns (@realcodywburns)
 * Afri Schoedon (@soc1c)


### PR DESCRIPTION
I propose demoting wei tang as ecip editor for not stopping to block community efforts on ecbp 1076 in #194 which received rough consensus in the public community call in #174 without stating actual reasons.