### PR TITLE
Enable 44-VERTXN extension to make ecosystem tooling backward compatible

### DIFF
--- a/_specs/ecip-1065.md
+++ b/_specs/ecip-1065.md
@@ -23,7 +23,9 @@ changes specified in "Specification" section.
 
 ### Specification
 
-At hard fork block, enable [EIP-1702](https://eips.ethereum.org/EIPS/eip-1702):
+At hard fork block, enable
+[EIP-1702](https://eips.ethereum.org/EIPS/eip-1702) with
+[44-VERTXN](https://specs.that.world/44-vertxn/) extension.
 
 * Define the previous EVM version as version `0`.
 * Define a new version `1`, with the following EVM modifications
@@ -52,23 +54,21 @@ about.
 
 #### Ecosystem
 
-It is possible to deploy a helper contract to allow version `0`
-contracts continue to be created. This allows unmodified Solidity code
-to be deployed, just like what we have now.
+Ecosystem tooling remains backward compatible. We can continue to use
+unmodified Solidity compiler, as well as other smart contract tools,
+to develop and deploy contracts on legacy EVM at version `0`.
 
-However, for version `1`, because we made several changes related to
-gas cost, which impacts the semantics of certain opcodes such as
-`CALL*` and `CREATE*`, Solidity compiler must be modified to support
-version `1`.
-
-Existing common practices might need to change as well. Some practices
-relies on the observable behavior of gas cost. Relying on gas cost is
-usually considered to be a bad practice because gas cost can and will
-change.
-
-On the other hand, version `1` enables some new practices that wasn't
-possible before. For example, a contract can now refuse to be invoked
-by any other contracts.
+If developers want to take advantage of forward-compatible EVM at
+version `1`, because we made several changes related to gas cost,
+which impacts the semantics of certain opcodes such as `CALL*` and
+`CREATE*`, Solidity compiler must be modified to support it. For
+version `1`, existing common practices might need to change as
+well. Some practices relies on the observable behavior of gas
+cost. Relying on gas cost is usually considered to be a bad practice
+because gas cost can and will change. On the other hand, version `1`
+also enables some new practices that wasn't possible before. For
+example, a contract can now refuse to be invoked by any other
+contracts.
 
 #### Emergency Hard Fork
 


### PR DESCRIPTION
This enables 44-VERTXN extension for EIP-1702, so that ecosystem tooling remains backward compatible.