### PR TITLE
ECIP-1072: Fix name and move it to last call

### DIFF
--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -2,7 +2,8 @@
 lang: en
 ecip: 1072
 title: Aztlán EVM and Protocol Upgrades (Yingchun Edition)
-status: Draft
+status: Last Call
+review-period-end: 2019-12-21
 type: Meta
 author: Wei Tang (@sorpaas), Talha Cross (@soc1c), Bob Summerwill (@bobsummerwill)
 created: 2019-11-14

--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -1,10 +1,10 @@
 ---
 lang: en
 ecip: 1072
-title: Yingchun EVM and Protocol Upgrades
+title: Aztlán EVM and Protocol Upgrades (Yingchun Edition)
 status: Draft
 type: Meta
-author: Wei Tang (@sorpaas)
+author: Wei Tang (@sorpaas), Talha Cross (@soc1c)
 created: 2019-11-14
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
 license: Apache-2.0

--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -4,7 +4,7 @@ ecip: 1072
 title: Aztlán EVM and Protocol Upgrades (Yingchun Edition)
 status: Draft
 type: Meta
-author: Wei Tang (@sorpaas), Talha Cross (@soc1c)
+author: Wei Tang (@sorpaas), Talha Cross (@soc1c), Bob Summerwill (@bobsummerwill)
 created: 2019-11-14
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
 license: Apache-2.0


### PR DESCRIPTION
This moves ECIP-1072 into last call status, with review period of 3 weeks, as discussed on the call.