### PR TITLE
Proposal to reject ECIP-1021, ECIP-1051, ECIP-1052 and ECIP-1057

### DIFF
--- a/_specs/ecip-1021.md
+++ b/_specs/ecip-1021.md
@@ -2,8 +2,8 @@
 lang: en
 ecip: 1021
 title: Token standard
-author: Dexaran, <dexaran820@gmail.com>
-status: Draft
+author: Dexaran (@Dexaran)
+status: Rejected
 type: Standards Track
 category: ECBP
 created: 2017-03-07

--- a/_specs/ecip-1052.md
+++ b/_specs/ecip-1052.md
@@ -2,9 +2,9 @@
 lang: en
 ecip: 1052
 title: Smart-contract Security Auditing core
-status: Draft
+status: Rejected
 type: Meta
-author: Dexaran, dexaran@ethereumclassic.org
+author: Dexaran (@Dexaran)
 created: 2018-12-31
 ---
 

--- a/_specs/ecip-1057.md
+++ b/_specs/ecip-1057.md
@@ -2,9 +2,9 @@
 lang: en
 ecip: 1057
 title: Cold Staking
-author: Dexaran, dexaran@ethereumclassic.org
+author: Dexaran (@Dexaran)
 discussions-To: https://github.com/ethereumclassic/ECIPs/issues/65
-status: Draft
+status: Rejected
 type: Standards Track
 category: Core
 created: 2019-03-31


### PR DESCRIPTION
Proposal to reject the following ECIPs:

ECIP-1021 - Token standard (= ERC-223 in Ethereum)
ECIP-1051 - Ethereum Classic Treasury system
ECIP-1052 - Smart-contract Security Auditing core
ECIP-1057 - Cold Staking

There is no support for these proposals.
Realistically they will never happen.

If new champions wish to propose similar changes in the future they should create new ECIPs.
We should reduce our cognitive load and the clarify of our "working set" by pruning out such inactive or "never going to happen" proposals.

Dexaran has indicated that his efforts will now be applied against EOS and I wish him the best with that approach.   https://twitter.com/BobSummerwill/status/1199718315683237888

Nobody has championed treasury proposals except for Dexaran either, and treasury proposals are deeply unpopular within ETC.