### PR TITLE
Correct status for various ECIPs which appear wrong

### DIFF
--- a/_specs/ecip-1019.md
+++ b/_specs/ecip-1019.md
@@ -3,7 +3,7 @@ lang: en
 ecip: 1019
 title: (Epoch Decay 10) Monetary Policy and Final Modification to the Ethereum Classic Emission Schedule
 author: Mike Boremi <ecip-1019@mikes.email>
-status: Draft
+status: Withdrawn
 type: Standards Track
 category: Core
 created: 2017-01-19

--- a/_specs/ecip-1045.md
+++ b/_specs/ecip-1045.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1045
 title: Support for ETH Byzantium & Constantinople EVM and Protocol Upgrades
-status: Draft
+status: Withdrawn
 type: Meta
 author: Isaac Ardis <isaac@etcdevteam.com>
 created: 2018-06-18

--- a/_specs/ecip-1048.md
+++ b/_specs/ecip-1048.md
@@ -4,7 +4,7 @@ ecip: 1048
 title: Clique proof-of-authority consensus protocol
 author: Péter Szilágyi <peterke@gmail.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/225
-status: Draft
+status: Last Call
 type: Standards Track
 category: Core
 created: 2017-03-06


### PR DESCRIPTION
ECIP-1019 (to withdrawn, was obsoleted by other ECIPs)
ECIP-1045 (to withdrawn, was obsoleted by other ECIPs)
ECIP-1048 (to last call, because we already implemented it with Kotti)