### PR TITLE
ECIP-1000: ECIP Coordinators

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -110,7 +110,7 @@ ECIP editors are intended to fulfill administrative and editorial responsibiliti
 * Merge the pull request when it is ready.
 * List the ECIP in [[README.mediawiki]]
 
-### Corrdinating Steps
+### Coordinating Steps
 
 For important ECIP issues, core developers regularly hold meetings to gather rough consensus from the community. Those meetings may be conducted by ECIP editors, ECIP coordinators, or anyone else in the community who might be willing to volunteer. Coordinators of a meeting should:
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -78,13 +78,21 @@ The current ECIP editors are:
 * Afri Schoedon (@soc1c)
 * Yaz Khoury (@YazzyYaz)
 
-## ECIP Editor Responsibilities & Workflow
+## ECIP Coordinators
+
+The current ECIP coordinators are:
+
+* @phyro
+* @TokenHash
+* @developerkevin
+
+## Responsibilities & Workflow
 
 ### Introduction
 
 ECIP editors are intended to fulfill administrative and editorial responsibilities. ECIP editors monitor ECIP changes, and update ECIP headers as appropriate.
 
-### Steps
+### Editing Steps
 
 **1:** Each new ECIP should first be submitted as a **"pull request"** to the [ECIPs git repository](https://github.com/ethereumclassic/ECIPs). Then, an editor does the following:
 
@@ -101,6 +109,16 @@ ECIP editors are intended to fulfill administrative and editorial responsibiliti
 * Assign a ECIP number in the pull request.
 * Merge the pull request when it is ready.
 * List the ECIP in [[README.mediawiki]]
+
+### Corrdinating Steps
+
+For important ECIP issues, core developers regularly hold meetings to gather rough consensus from the community. Those meetings may be conducted by ECIP editors, ECIP coordinators, or anyone else in the community who might be willing to volunteer. Coordinators of a meeting should:
+
+* Decide on a meeting date, time and location that is available to as many community members as possible.
+* Provide an acceptable meeting agenda, and on the call, drive the meeting agenda forward for participants.
+* Record the meeting notes and make it available to the public.
+
+Meeting coordinators should be rotating, in order to offload the burden, and to avoid abuse of the meeting process.
 
 # ECIP Format and Structure
 


### PR DESCRIPTION
For important ECIP issues, core developers regularly hold meetings to gather rough consensus from the community. Those meetings may be conducted by ECIP editors, ECIP coordinators, or anyone else in the community who might be willing to volunteer. Coordinators of a meeting should:

* Decide on a meeting date, time and location that is available to as many community members as possible.
* Provide an acceptable meeting agenda, and on the call, drive the meeting agenda forward for participants.
* Record the meeting notes and make it available to the public.

Meeting coordinators should be rotating, in order to offload the burden, and to avoid abuse of the meeting process.

For this PR, I'm adding the initial ECIP Coordinators list as https://github.com/ethereumclassic/ECIPs/issues/209 grows (excluding already-assigned ECIP editors, as I assume they're already coordinators).