### PR TITLE
ECIP-1072: Move to withdrawn status

### DIFF
--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -1,11 +1,10 @@
 ---
 lang: en
 ecip: 1072
-title: Aztlán EVM and Protocol Upgrades (Yingchun Edition)
-status: Last Call
-review-period-end: 2019-12-21
+title: Yingchun EVM and Protocol Upgrades
+status: Draft
 type: Meta
-author: Wei Tang (@sorpaas), Talha Cross (@soc1c), Bob Summerwill (@bobsummerwill)
+author: Wei Tang (@sorpaas)
 created: 2019-11-14
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
 license: Apache-2.0

--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1072
 title: Yingchun EVM and Protocol Upgrades
-status: Draft
+status: Withdrawn
 type: Meta
 author: Wei Tang (@sorpaas)
 created: 2019-11-14

--- a/_specs/ecip-1073.md
+++ b/_specs/ecip-1073.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1073
 title: Xichun EVM and Protocol Upgrades
-status: Draft
+status: Withdrawn
 type: Meta
 author: Wei Tang (@sorpaas)
 created: 2019-11-14

--- a/_specs/ecip-1074.md
+++ b/_specs/ecip-1074.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1074
 title: Tanchun EVM and Protocol Upgrades
-status: Draft
+status: Withdrawn
 type: Meta
 author: Wei Tang (@sorpaas)
 created: 2019-11-14


### PR DESCRIPTION
Reverts #198 and move ECIP-1072 to withdrawn status.

Closes #207.

We already have ECIP-1061 that specifies the hardfork. Stop messing around with Ethereum Classic.