### PR TITLE
Remove Bob as author of ECIP-1072

### DIFF
--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -5,7 +5,7 @@ title: Aztlán EVM and Protocol Upgrades (Yingchun Edition)
 status: Last Call
 review-period-end: 2019-12-21
 type: Meta
-author: Wei Tang (@sorpaas), Talha Cross (@soc1c), Bob Summerwill (@bobsummerwill)
+author: Wei Tang (@sorpaas), Talha Cross (@soc1c)
 created: 2019-11-14
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/81
 license: Apache-2.0


### PR DESCRIPTION
He did not author this ECIP.
There was no consent to add him.
He actively opposes this ECIP, and supports ECIP-1061.