### PR TITLE
Reject ECIP-1072 which is a functional duplicate to ECIP-1061

### DIFF
--- a/_specs/ecip-1072.md
+++ b/_specs/ecip-1072.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1072
 title: Aztlán EVM and Protocol Upgrades (Yingchun Edition)
-status: Last Call
+status: Rejected
 review-period-end: 2019-12-21
 type: Meta
 author: Wei Tang (@sorpaas), Talha Cross (@soc1c), Bob Summerwill (@bobsummerwill)


### PR DESCRIPTION
ECIP-1702 is now being used by Wei to push an "Ethereum Classic Classic" fork.