### PR TITLE
ECIP-1051: Reject "Ethereum Classic Treasury system"

### DIFF
--- a/_specs/ecip-1051.md
+++ b/_specs/ecip-1051.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1051
 title: Ethereum Classic Treasury system
-status: Draft
+status: Rejected
 type: Standards Track
 category: Core
 author: Dexaran (@dexaran)


### PR DESCRIPTION
There has been no work on this proposal (or the earlier IOHK treasury proposal).
There is broad consensus that changing the block rewards to add treasury model is unacceptable.
The Monetary Policy (ECIP-1017) defines the ETC system and gives multi-decade certainty to all ETC ecosystem participants.

If we need to have a discussion of this on ETC Core Developers call then we should.
And then Reject it.