### PR TITLE
ECIP-1052: Reject "Smart-contract Security Auditing core"

### DIFF
--- a/_specs/ecip-1052.md
+++ b/_specs/ecip-1052.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1052
 title: Smart-contract Security Auditing core
-status: Draft
+status: Rejected
 type: Meta
 author: Dexaran, dexaran@ethereumclassic.org
 created: 2018-12-31


### PR DESCRIPTION
This requires the Treasury.
Both the Treasury and this Auditing proposal on top run counter to ECIP-1017 monetary policy.

Auditing is a good idea, but should not be centralized into the block rewards.

This runs counter to ETC philosophy and principles and should be rejected.

Perhaps this is raised in an ETC Core Developers call, and formally rejected?