### PR TITLE
ECIP-1021: Move ERC-223 token standard to Last Call, on its path to Accepted and then Final.

### DIFF
--- a/_specs/ecip-1021.md
+++ b/_specs/ecip-1021.md
@@ -1,9 +1,9 @@
 ---
 lang: en
 ecip: 1021
-title: Token standard
+title: ERC-223 Token standard
 Author: Dexaran (@dexaran)
-status: Draft
+status: Last Call
 type: Standards Track
 category: ECBP
 created: 2017-03-07


### PR DESCRIPTION
This token standard is being used in the real world.