### PR TITLE
ECIP-1000: Clarify that @soc1c is a pesedo-anonymous ECIP editor

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -75,8 +75,11 @@ The current ECIP editors are:
 * Wei Tang (@sorpaas)
 * Isaac Ardis (@meowsbits)
 * Cody Burns (@realcodywburns)
-* Afri Schoedon (@soc1c)
 * Yaz Khoury (@YazzyYaz)
+
+The following ECIP editors have decided to remain pesedo-anonymous, and we will only be refer to them using Github handles:
+
+* @soc1c
 
 ## ECIP Editor Responsibilities & Workflow
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -77,7 +77,7 @@ The current ECIP editors are:
 * Cody Burns (@realcodywburns)
 * Yaz Khoury (@YazzyYaz)
 
-The following ECIP editors have decided to remain pesedo-anonymous, and we will only be refer to them using Github handles:
+The following ECIP editors have decided to remain pesedo-anonymous, and we will only be referring to them using Github handles:
 
 * @soc1c
 


### PR DESCRIPTION
@soc1c has expressed that he does not intend that handle to be associated with his real name. This is to clarify in the ECIP that it's a pesedo-anonymous ECIP editor.