### PR TITLE
ECIP-1000: Clarify that @soc1c and @meowsbits are pseudonymous ECIP editors

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -75,8 +75,8 @@ The current ECIP editors are:
 * Wei Tang (@sorpaas)
 * Cody Burns (@realcodywburns)
 * Yaz Khoury (@YazzyYaz)
-* @soc1c (Anonymous)
-* @meowsbits (Anonymous)
+* @soc1c (Pseudonymous)
+* @meowsbits (Pseudonymous)
 
 ## ECIP Editor Responsibilities & Workflow
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -73,10 +73,13 @@ A good reason to transfer ownership is because the original author no longer has
 The current ECIP editors are:
 
 * Wei Tang (@sorpaas)
-* Isaac Ardis (@meowsbits)
 * Cody Burns (@realcodywburns)
-* Afri Schoedon (@soc1c)
 * Yaz Khoury (@YazzyYaz)
+
+The following ECIP editors have decided to remain pesedo-anonymous, and we will only be referring to them using Github handles:
+
+* @meowsbits
+* @soc1c
 
 ## ECIP Editor Responsibilities & Workflow
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -75,11 +75,8 @@ The current ECIP editors are:
 * Wei Tang (@sorpaas)
 * Cody Burns (@realcodywburns)
 * Yaz Khoury (@YazzyYaz)
-
-The following ECIP editors have decided to remain pesedo-anonymous, and we will only be referring to them using Github handles:
-
-* @meowsbits
-* @soc1c
+* @soc1c (Anonymous)
+* @meowsbits (Anonymous)
 
 ## ECIP Editor Responsibilities & Workflow
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -75,8 +75,8 @@ The current ECIP editors are:
 * Wei Tang (@sorpaas)
 * Cody Burns (@realcodywburns)
 * Yaz Khoury (@YazzyYaz)
-* @soc1c (Pseudonymous)
-* @meowsbits (Pseudonymous)
+* @soc1c (Talha Cross, Pseudonymous)
+* @meowsbits (Mr. Meows D. Bits, Pseudonymous)
 
 ## ECIP Editor Responsibilities & Workflow
 


### PR DESCRIPTION
@soc1c and @meowsbits has expressed that he does not intend that handle to be associated with his real name. This is to clarify in the ECIP that it's a pesedo-anonymous ECIP editor.