### PR TITLE
ecip-1056: add review period and block to agharta

### DIFF
--- a/_specs/ecip-1056.md
+++ b/_specs/ecip-1056.md
@@ -3,6 +3,7 @@ lang: en
 ecip: 1056
 title: Agharta EVM and Protocol Upgrades
 status: Last Call
+review-period-end: 2019-12-19
 type: Meta
 author: Isaac Ardis <isaac.a@etclabs.org>, Wei Tang <hi@that.world>
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/131
@@ -28,7 +29,7 @@ This document proposes the following blocks at which to implement these changes 
 - `5_000_381` on Morden Classic Testnet (November 13, 2019)
 - `301_243` on Mordor Classic Testnet (November 20, 2019)
 - `1_705_549` on Kotti Classic Testnet (December 11, 2019)
-- `TBD` on Ethereum Classic Mainnet (January 15, 2020)
+- `9_573_000` on Ethereum Classic Mainnet (January 15, 2020)
 
 For more information on the opcodes and their respective EIPs and implementations, please see the _Specification_
 section of this document.


### PR DESCRIPTION
as agreed on the call today:

- add `review-period-end: 2019-12-19` meta data
- update block number to `9_573_000` on Ethereum Classic Mainnet (January 15, 2020)

closes #175 

note: agharta will be moved to accepted after the review period ends without any subsequent call unless the spec will be openly disputed.