### PR TITLE
Integrate a Minimal Code of Conduct in the ECIP Process

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -359,7 +359,7 @@ In addition, it is recommended that literal code included in the ECIP be dual-li
 
 ## ECIP Participants Will Adhere to the Following
 
-1. Anyone can participate in the ECIP as a competent developer, miner, validator, node operator, user, or any other prescribed participant or stakeholder.
+1. Anyone can participate in the ECIP process as a competent developer, miner, validator, node operator, user, or any other prescribed participant or stakeholder.
 2. Within the ECIP documents and discussion pages, participants will conduct themselves professionally, focusing on ECIP issues, making sure their arguments are well founded, minimizing trolling, insulting or derogatory comments, and personal or political attacks.
 3. Participant privacy will be respected. Publishing other participant’s private information, such as a physical or email addresses, or real names, without their explicit permission is not allowed within the ECIP process nor in other public forums.
 4. Ethereum Classic organization owners on Github or other platform in use, ECIP editors, and ECIP coordinators have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to ECIP-1000 and Code of Conduct, and will communicate reasons for moderation decisions when appropriate.

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -103,6 +103,8 @@ ECIP editors are intended to fulfill administrative and editorial responsibiliti
 * Merge the pull request when it is ready.
 * List the ECIP in [[README.mediawiki]]
 
+ECIP editors also help enforce the [ECIP Process Code of Conduct](https://github.com/ethereumclassic/ECIPs/blob/master/ECIPs/ECIP-1000.mediawiki#ecip-process-code-of-conduct) described below in this document.
+
 # ECIP Format and Structure
 
 ## Specification
@@ -352,6 +354,19 @@ In addition, it is recommended that literal code included in the ECIP be dual-li
 
 * Some ECIPs, especially consensus layer, may include literal code in the ECIP itself which may not be available under the exact license terms of the ECIP.
 * Despite this, not all software licenses would be acceptable for content included in ECIPs.
+
+# ECIP Process Code of Conduct
+
+## ECIP Participants Will Adhere to the Following
+
+1. Anyone can participate in the ECIP as a competent developer, miner, validator, node operator, user, or any other prescribed participant or stakeholder.
+2. Within the ECIP documents and discussion pages, participants will conduct themselves professionally, focusing on ECIP issues, making sure their arguments are well founded, minimizing trolling, insulting or derogatory comments, and personal or political attacks.
+3. Participant privacy will be respected. Publishing other participant’s private information, such as a physical or email addresses, or real names, without their explicit permission is not allowed within the ECIP process nor in other public forums.
+4. Ethereum Classic organization owners on Github or other platform in use, ECIP editors, and ECIP coordinators have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to ECIP-1000 and Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Rationale
+
+Although in a permissionless open source system as Ethereum Classic the ideal is to minimize rules and to be as open as possible, it is also important to protect participant privacy, have a professional proposal and discussion dynamic, and minimize harassment. These goals help guarantee openness and maintain a high technical and knowleadgeable set of participants in the process.
 
 # See Also
 


### PR DESCRIPTION
Although I oppose ECIP-1001, after some deliberation with other ETC participants ,I propose this minimal **ECIP Process Code of Conduct** to be integrated into ECIP-1000, as described in this PR, to help protect the process while maintaining the most openness to competent devs, and other participants on a global level.

If this PR is merged, then ECIP-1001 should not be necessary.