### PR TITLE
Progress ECIP-1048 (Clique) to Final Call.

### DIFF
--- a/_specs/ecip-1048.md
+++ b/_specs/ecip-1048.md
@@ -4,7 +4,7 @@ ecip: 1048
 title: Clique proof-of-authority consensus protocol
 author: Péter Szilágyi <peterke@gmail.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/225
-status: Draft
+status: Last Call
 type: Standards Track
 category: Core
 created: 2017-03-06


### PR DESCRIPTION
It was implemented a long time ago, but the ECIP was never updated.
We have to move it to Final Call first and then after is has been in that status, we can move it to Accepted, and then on to Final.
This is just house-keeping.