### PR TITLE
ECIP-1081: No number in this ECIP

### DIFF
--- a/_specs/ecip-1081.md
+++ b/_specs/ecip-1081.md
@@ -1,6 +1,6 @@
 ---
 lang: en
-ecip: **Please assign a number here and on the ECIP URL <-**
+ecip: 1081
 title: Do Not Dox ECIP Editors
 author: Bob Summerwill (@bobsummerwill)
 status: Draft

--- a/_specs/ecip-do_not_dox.md
+++ b/_specs/ecip-do_not_dox.md
@@ -1,6 +1,6 @@
 ---
 lang: en
-ecip: Unassigned
+ecip: **Please assign a number here <-**
 title: Do Not Dox ECIP Editors
 author: Bob Summerwill (@bobsummerwill)
 status: Draft

--- a/_specs/ecip-do_not_dox.md
+++ b/_specs/ecip-do_not_dox.md
@@ -1,6 +1,6 @@
 ---
 lang: en
-ecip: **Please assign a number here <-**
+ecip: **Please assign a number here and on the ECIP URL <-**
 title: Do Not Dox ECIP Editors
 author: Bob Summerwill (@bobsummerwill)
 status: Draft


### PR DESCRIPTION
Seems this ECIP was merged without a number. The actual underlying correction proposed was done in ECIP-1000 through another PR https://github.com/ethereumclassic/ECIPs/pull/267, so this ECIP may either get a number and moved to "Active" so it agrees with the ECIP process format, or it may be deleted.