### PR TITLE
ECIP-1078: feature timing convention block number

### DIFF
--- a/_specs/ecip-1078.md
+++ b/_specs/ecip-1078.md
@@ -42,7 +42,7 @@ This document proposes the following blocks at which to implement these changes 
 - `2_058_191` on Kotti Classic PoA-testnet (Feb 12th, 2020)
 - `10_500_839` on Ethereum Classic PoW-mainnet (March 25th, 2020)
 
-After HARD_FORK_BLOCK, apply the following changes:
+At HARD_FORK_BLOCK, apply the following changes:
 
 - Disable [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200)
 - Enable [EIP-1283](https://eips.ethereum.org/EIPS/eip-1283) with [EIP-1706](https://eips.ethereum.org/EIPS/eip-1706) instead.


### PR DESCRIPTION
Feature-enable specifications conventionally use block numbers as inclusive
starting points, as opposed to last-without variables.

This commit edits the specification section assuming that that was what was
intended.