### PR TITLE
ECIP-1079: feature timing convention block number

### DIFF
--- a/_specs/ecip-1079.md
+++ b/_specs/ecip-1079.md
@@ -61,7 +61,7 @@ This document proposes the following blocks at which to implement these changes 
 - TBD Kotti Classic PoA-testnet
 - TBD on Ethereum Classic PoW-mainnet
 
-After HARD_FORK_BLOCK, apply the following changes.
+At HARD_FORK_BLOCK, apply the following changes.
 
 - Enable [EIP-152](https://eips.ethereum.org/EIPS/eip-152)
 - Enable [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108)


### PR DESCRIPTION
Feature-enable specifications conventionally use block numbers as inclusive
starting points, as opposed to last-without variables.

This commit edits the specification section assuming that that was what was
intended.

Rel #281 