### PR TITLE
Withdraw ECIP-1081 Do Not Dox ECIP Editors.

### DIFF
--- a/_specs/ecip-1081.md
+++ b/_specs/ecip-1081.md
@@ -3,12 +3,18 @@ lang: en
 ecip: 1081
 title: Do Not Dox ECIP Editors
 author: Bob Summerwill (@bobsummerwill)
-status: Draft
+status: Withdrawn
 type: Meta
 created: 2020-01-19
 license: Apache-2.0
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/272
 ---
+
+###  NOTE
+
+The ECIP was replaced by [ECIP-0001 - ECIP process](https://github.com/ethereumclassic/ECIPs/pull/277/files)
+and was never activated.
+
 
 ### Abstract
 


### PR DESCRIPTION
It was replaced by ECIP-0001 ECIP process.