### PR TITLE
Move ECIP-1078 ("fix") to Last Call.  Move ECIP-1079 ("redo") to Withdrawn.

### DIFF
--- a/_specs/ecip-1061.md
+++ b/_specs/ecip-1061.md
@@ -31,9 +31,9 @@ _Istanbul_ hardforks. The proposed changes for Ethereum Classic's _Aztlán_ upgr
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- `778_507` on Mordor Classic PoW-testnet (Feb 5th, 2020)
-- `2_058_191` on Kotti Classic PoA-testnet (Feb 12th, 2020)
-- `10_500_839` on Ethereum Classic PoW-mainnet (March 25th, 2020)
+- `778_507` on Mordor Classic PoW-testnet (activated on Jan 30th, 2020)
+- `2_058_191` on Kotti Classic PoA-testnet (~Feb 14th, 2020)
+- `10_500_839` on Ethereum Classic PoW-mainnet (~June, 2020)
 
 For more information on the opcodes and their respective EIPs and implementations, please see the _Specification_
 section of this document.

--- a/_specs/ecip-1061.md
+++ b/_specs/ecip-1061.md
@@ -32,8 +32,8 @@ _Istanbul_ hardforks. The proposed changes for Ethereum Classic's _Aztlán_ upgr
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
 - `778_507` on Mordor Classic PoW-testnet (activated on Jan 30th, 2020)
-- `2_058_191` on Kotti Classic PoA-testnet (~Feb 14th, 2020)
-- `10_500_839` on Ethereum Classic PoW-mainnet (~May/June, 2020)
+- `2_058_191` on Kotti Classic PoA-testnet (approx Feb 12th, 2020)
+- `10_500_839` on Ethereum Classic PoW-mainnet (approx Jun 10th, 2020)
 
 For more information on the opcodes and their respective EIPs and implementations, please see the _Specification_
 section of this document.

--- a/_specs/ecip-1061.md
+++ b/_specs/ecip-1061.md
@@ -33,7 +33,7 @@ This document proposes the following blocks at which to implement these changes 
 
 - `778_507` on Mordor Classic PoW-testnet (activated on Jan 30th, 2020)
 - `2_058_191` on Kotti Classic PoA-testnet (~Feb 14th, 2020)
-- `10_500_839` on Ethereum Classic PoW-mainnet (~June, 2020)
+- `10_500_839` on Ethereum Classic PoW-mainnet (~May/June, 2020)
 
 For more information on the opcodes and their respective EIPs and implementations, please see the _Specification_
 section of this document.

--- a/_specs/ecip-1078.md
+++ b/_specs/ecip-1078.md
@@ -4,6 +4,7 @@ ecip: 1078
 title: Phoenix EVM and Protocol Upgrades ("Aztlán fix")
 author: Bob Summerwill (@bobsummerwill)
 status: Last Call
+review-period-end: 2020-03-30
 type: Meta
 created: 2020-01-19
 license: Apache-2.0
@@ -38,9 +39,9 @@ would result in protocol changes which met the original intent.
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- TBD on Mordor Classic PoW-testnet (TBD)
-- TBD on Kotti Classic PoA-testnet (TBD)
-- `10_500_839` on Ethereum Classic PoW-mainnet (March 25th, 2020)
+- `976_231` on Mordor Classic PoW-testnet (March 4th, 2020)
+- `2_208_203` on Kotti Classic PoA-testnet (March 11st, 2020)
+- TBD on Ethereum Classic PoW-mainnet (April/May/June 2020)
 
 At HARD_FORK_BLOCK, apply the following changes:
 

--- a/_specs/ecip-1078.md
+++ b/_specs/ecip-1078.md
@@ -39,9 +39,9 @@ would result in protocol changes which met the original intent.
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- `976_231` on Mordor Classic PoW-testnet (~March 4th, 2020)
-- `2_208_203` on Kotti Classic PoA-testnet (~March 11st, 2020)
-- `10_500_839` on Ethereum Classic PoW-mainnet (~May/June, 2020)
+- `976_231` on Mordor Classic PoW-testnet (approx March 4th, 2020)
+- `2_208_203` on Kotti Classic PoA-testnet (approx March 11st, 2020)
+- `10_500_839` on Ethereum Classic PoW-mainnet (approx June 10th, 2020)
 
 At HARD_FORK_BLOCK, apply the following changes:
 

--- a/_specs/ecip-1078.md
+++ b/_specs/ecip-1078.md
@@ -39,9 +39,9 @@ would result in protocol changes which met the original intent.
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- `976_231` on Mordor Classic PoW-testnet (March 4th, 2020)
-- `2_208_203` on Kotti Classic PoA-testnet (March 11st, 2020)
-- TBD on Ethereum Classic PoW-mainnet (April/May/June 2020)
+- `976_231` on Mordor Classic PoW-testnet (~March 4th, 2020)
+- `2_208_203` on Kotti Classic PoA-testnet (~March 11st, 2020)
+- `10_500_839` on Ethereum Classic PoW-mainnet (~May/June, 2020)
 
 At HARD_FORK_BLOCK, apply the following changes:
 

--- a/_specs/ecip-1078.md
+++ b/_specs/ecip-1078.md
@@ -1,9 +1,9 @@
 ---
 lang: en
 ecip: 1078
-title: Phoenix EVM and Protocol Upgrades
+title: Phoenix EVM and Protocol Upgrades ("Aztlán fix")
 author: Bob Summerwill (@bobsummerwill)
-status: Draft
+status: Last Call
 type: Meta
 created: 2020-01-19
 license: Apache-2.0
@@ -12,7 +12,7 @@ discussions-to: https://github.com/ethereumclassic/ECIPs/issues/262
 
 ### Simple Summary
 
-This ECIP describes a hard-fork which would occur at the same block as
+This ECIP describes a hard-fork which would occur at the same mainnet block as
 [ECIP 1061: Aztlán EVM and Protocol Upgrades (Yingchun Edition)](https://ecips.ethereumclassic.org/ECIPs/ecip-1061) to "fix" two issues with ECIP-1061 where the written specification
 did not match the original intent.
 
@@ -38,8 +38,8 @@ would result in protocol changes which met the original intent.
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- `778_507` on Mordor Classic PoW-testnet (Feb 5th, 2020)
-- `2_058_191` on Kotti Classic PoA-testnet (Feb 12th, 2020)
+- TBD on Mordor Classic PoW-testnet (TBD)
+- TBD on Kotti Classic PoA-testnet (TBD)
 - `10_500_839` on Ethereum Classic PoW-mainnet (March 25th, 2020)
 
 At HARD_FORK_BLOCK, apply the following changes:

--- a/_specs/ecip-1079.md
+++ b/_specs/ecip-1079.md
@@ -1,14 +1,31 @@
 ---
 lang: en
 ecip: 1079
-title: Phoenix EVM and Protocol Upgrades
+title: Phoenix EVM and Protocol Upgrades ("Aztlán redo")
 author: Bob Summerwill (@bobsummerwill)
-status: Draft
+status: Withdrawn
 type: Meta
 created: 2020-01-19
 license: Apache-2.0
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/263
 ---
+
+###  NOTE
+
+This ECIP was rendered unworkable when
+[ECIP 1061: Aztlán EVM and Protocol Upgrades (Yingchun Edition)](https://ecips.ethereumclassic.org/ECIPs/ecip-1061)
+was activated to the Mordor testnet.  It was no longer possible for the original Aztlán
+hardfork to be Withdrawn and replaced with this ECIP.
+
+The most likely path forward at the time of writing is for 
+[ECIP 1078: Phoenix EVM and Protocol Upgrades ("Aztlán redo")](https://ecips.ethereumclassic.org/ECIPs/ecip-1061)
+to be moved to Last Call and to have block numbers assigned and to proceed with activation on
+Mordor and Kotti testnets slightly later than the Aztlán activation but activating on the same
+block for ETC mainnet.
+
+There will be a [Core Devs Call: ECIP-1078 Phoenix Upgrade](https://github.com/ethereumclassic/ECIPs/issues/284)
+on Wednesday, February 05, 2019, 4pm UTC, 60 minutes max to make the final decision on this.
+
 
 ### Simple Summary
 


### PR DESCRIPTION
Move ECIP-1078 ("fix") to Last Call.
Move ECIP-1079 ("redo") to Withdrawn.
Aztlán has activated on the Mordor testnet, so can no longer be withdrawn.
Proceeding with "fix" appears to be our best option.