### PR TITLE
Move ECIP 1080: SELFBALANCE opcode to Last Draft.

### DIFF
--- a/_specs/ecip-1080.md
+++ b/_specs/ecip-1080.md
@@ -3,8 +3,10 @@ lang: en
 ecip: 1080
 title: SELFBALANCE opcode
 author: Bob Summerwill (@bobsummerwill)
-status: Draft
-type: Meta
+status: Last Call
+review-period-end: 2020-03-30
+type: Standards Track
+category: Core
 created: 2020-01-19
 license: Apache-2.0
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/266


### PR DESCRIPTION
This should have happened at the same time as ECIP 1078: Phoenix EVM and Protocol Upgrades ("Aztlán fix") was moved.
Also correcting "type" and "category" from Meta to Standards Track.
That was a cut-and-paste error.