### PR TITLE
Move ECIP-1048 Clique proof-of-authority consensus protocol to Final.

### DIFF
--- a/_specs/ecip-1048.md
+++ b/_specs/ecip-1048.md
@@ -4,7 +4,7 @@ ecip: 1048
 title: Clique proof-of-authority consensus protocol
 author: Péter Szilágyi <peterke@gmail.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/225
-status: Last Call
+status: Final
 type: Standards Track
 category: Core
 created: 2017-03-06


### PR DESCRIPTION
Kotti has been live for over a year.
Clique is implemented in Parity-Ethereum, Multi-Geth and Hyperledger Besu.
This ECIP just got left unprocessed.