### PR TITLE
Move ECIP 1050: Status Codes to Final.

### DIFF
--- a/_specs/ecip-1050.md
+++ b/_specs/ecip-1050.md
@@ -4,8 +4,8 @@ ecip: 1050
 title: Status Codes
 author: Brooklyn Zelenka (@expede), Boris Mann (@bmann)
 discussions-to: https://fission.codes/blockchain/ethclassic
-status: Last Call
-type: Standars Track
+status: Final
+type: Standards Track
 category: ECBP
 created: 2018-12-03
 ---


### PR DESCRIPTION
It has been in Last Call since October.
People are using this standard in the real world.
The standard is not changing.
This is a best practice, not consensus.