### PR TITLE
ECIP-1086: SLOAD Gas Patch for the Testnets

### DIFF
--- a/_specs/ecip-1086.md
+++ b/_specs/ecip-1086.md
@@ -60,6 +60,8 @@ Note, that accepting and merging these pull requests would either require to rol
 
 Adoption of the content of this ECIP requires a configuration for all clients to allow for configuring `SLOAD_GAS` as per [ECIP-1086](https://ecips.ethereumclassic.org/ECIPs/ecip-1086). The implementation cost is considered low.
 
+A sample implementation is available for _Besu_: [hyperledger/besu#382](https://github.com/hyperledger/besu/pull/382)
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/_specs/ecip-1086.md
+++ b/_specs/ecip-1086.md
@@ -60,7 +60,11 @@ Note, that accepting and merging these pull requests would either require to rol
 
 Adoption of the content of this ECIP requires a configuration for all clients to allow for configuring `SLOAD_GAS` as per [ECIP-1086](https://ecips.ethereumclassic.org/ECIPs/ecip-1086). The implementation cost is considered low.
 
-A sample implementation is available for _Besu_: [hyperledger/besu#382](https://github.com/hyperledger/besu/pull/382)
+An implementation is available for:
+
+* Hyperledger Besu: [hyperledger/besu#382](https://github.com/hyperledger/besu/pull/382)
+* Parity Ethereum: `N/A`
+* Multi-Geth: [etclabscore/multi-geth#151](https://github.com/etclabscore/multi-geth/pull/151)
 
 ## Copyright
 

--- a/_specs/ecip-1086.md
+++ b/_specs/ecip-1086.md
@@ -1,0 +1,65 @@
+---
+lang: en
+ecip: 1086
+title: SLOAD Gas Patch for the Classic Testnets
+status: Draft
+type: Standards Track
+category: Core
+author: Talha Cross <no-reply@soc1.cz>
+created: 2020-02-18
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/262
+---
+
+### Simple Summary
+
+Issues with the _Aztlán_ protocol upgrades were identified and sufficiently patched with the _Phoenix_ protocol upgrades. However, the subsequent activation of these upgrades on the _Kotti_ and _Mordor_ testnets revealed inconsistencies between client implementations. This document proposes a patch for the aforementioned testnets.
+
+### Abstract
+
+The [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) defines structured definitions of net-gas metering for the `SSTORE` opcode. This EIP was activated in a bundle called [EIP-1679](https://eips.ethereum.org/EIPS/eip-1679) "Istanbul" on the Ethereum Foundation network and [ECIP-1061](https://ecips.ethereumclassic.org/ECIPs/ecip-1061) "Aztlán" on the Ethereum Classic network.
+
+Notably, the difference here is that _Istanbul_ contained [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884) which repriced various opcodes for trie-size dependent operations, whereas _Aztlán_ did not.
+
+Both [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884) and [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) propose the `SLOAD_GAS` to be increased from `200` to `800` but not all clients correctly implemented this change for both EIPs leaving networks configured with a pick-and-mix EIP configuration such as _Aztlán_ with an incompatible configuration as compared to clients who correctly implemented the specifications.
+
+### Motivation
+
+This specification seeks to validate the incomplete configuration in favor of retaining the _Kotti_ and _Mordor_ testnets in consensus. This ECIP shall not be considered on mainnet. It's sole purpose is to allow avoiding a rollback on the testnets and having a proper documentation on the cause for the gas mismatch and providing instructions for client developers how to circumvent this.
+
+### Specification
+
+At `BLOCK_NUMBER` maintain a consistent `SLOAD_GAS` cost of `200`.
+
+This applies only under the condition:
+* that [ECIP-1061](https://ecips.ethereumclassic.org/ECIPs/ecip-1061) _Aztlán_ was activated without [ECIP-1078](https://ecips.ethereumclassic.org/ECIPs/ecip-1078) _Phoenix_,
+* OR that [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) was activated without [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884).
+
+A subsequent protocol upgrade disabling [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) (such as [ECIP-1078](https://ecips.ethereumclassic.org/ECIPs/ecip-1078) _Phoenix_) makes this gas pricing configuration obsolete if it's activated at the same `BLOCK_NUMBER`.
+
+This document proposes the following `BLOCK_NUMBER` at which to implement these changes in the Classic test networks:
+
+- `778_507` on _Mordor_ Classic PoW-testnet (Jan 30th, 2020)
+- `2_058_191` on _Kotti_ Classic PoA-testnet (Feb 12th, 2020)
+
+
+### Rationale
+
+The inconsistency was discovered in a consensus issue on the _Mordor_ Classic testnet between Hyperledger _Besu_, ETC Core _Multi-Geth_, and Parity Technologies _Parity Ethereum_.
+
+It turned out that _Besu_ correctly implemented [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) whereas _Parity_ and _Geth_ chose a _sloppy_ implementation under the assumption of having this gas change already included with [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884).
+
+The following code changes to the clients are relevant for this ECIP:
+
+* Foundation Geth: [ethereum/go-ethereum#20646](https://github.com/ethereum/go-ethereum/pull/20646)
+* Parity Ethereum: [paritytech/parity-ethereum#11474](https://github.com/paritytech/parity-ethereum/pull/11474)
+* Multi-Geth: [etclabscore/multi-geth#144](https://github.com/etclabscore/multi-geth/pull/144)
+
+Note, that accepting and merging these pull requests would either require to roll back the _Kotti_ and _Mordor_ testnets or to accept this [ECIP-1086](https://ecips.ethereumclassic.org/ECIPs/ecip-1086) to patch the `SLOAD` gas to `200`. As author of this proposal I will champion for a patch in favor of a rollback.
+
+### Implementation
+
+Adoption of the content of this ECIP requires a configuration for all clients to allow for configuring `SLOAD_GAS` as per [ECIP-1086](https://ecips.ethereumclassic.org/ECIPs/ecip-1086). The implementation cost is considered low.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Issues with the _Aztlán_ protocol upgrades were identified and sufficiently patched with the _Phoenix_ protocol upgrades. However, the subsequent activation of these upgrades on the _Kotti_ and _Mordor_ testnets revealed inconsistencies between client implementations. This document proposes a patch for the aforementioned testnets.

### Abstract
The [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) defines structured definitions of net-gas metering for the `SSTORE` opcode. This EIP was activated in a bundle called [EIP-1679](https://eips.ethereum.org/EIPS/eip-1679) "Istanbul" on the Ethereum Foundation network and [ECIP-1061](https://ecips.ethereumclassic.org/ECIPs/ecip-1061) "Aztlán" on the Ethereum Classic network.

Notably, the difference here is that _Istanbul_ contained [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884) which repriced various opcodes for trie-size dependent operations, whereas _Aztlán_ did not.

Both [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884) and [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) propose the `SLOAD_GAS` to be increased from `200` to `800` but not all clients correctly implemented this change for both EIPs leaving networks configured with a pick-and-mix EIP configuration such as _Aztlán_ with an incompatible configuration as compared to clients who correctly implemented the specifications.

### Motivation
This specification seeks to validate the incomplete configuration in favor of retaining the _Kotti_ and _Mordor_ testnets in consensus. This ECIP shall not be considered on mainnet. It's sole purpose is to allow avoiding a rollback on the testnets and having a proper documentation on the cause for the gas mismatch and providing instructions for client developers how to circumvent this.

### Discussions to:
- https://github.com/ethereumclassic/ECIPs/issues/262