### PR TITLE
ECIP1087 [Draft]: A way to resolve the ECIP1061/ECIP1078/ECIP1086/EIP2200 testnet fiasco (rollback Mordor, leave Kotti)

### DIFF
--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 
 Don't touch Kotti; allow ECIP1061, ECIP1078, and ECIP1086 (EIP2200, EIP2200Disable) to continue as specified and implemented there.
 
-Rollback Mordor to 750000 (3507 blocks prior to ECIP1061 activation), with ECIP1078 activation at block 778507 (same as ECIP1061).
+Set Mordor ECIP1078 activation to 778507 (equivalent to ECIP1061), and rollback to 750000.
 
 ### Motivation
 

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 
 Don't touch Kotti; allow ECIP1061, ECIP1078, and ECIP1086 (EIP2200, EIP2200Disable) to continue as specified and implemented there.
 
-Rollback Mordor to 750000, activate ECIP1078 at block 778508.
+Rollback Mordor to 750000, activate ECIP1078 at block 778507.
 
 ### Motivation
 

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -37,7 +37,7 @@ This means that protocol providers publishing releases which include ECIP1078 fo
 - Do correct EIP2200 before the fork, but follow specification (ECIP1086) to "allow" the incorrect EIP2200 implementation.
 - Do correct EIP2200 before the fork, but rollback the effected testnets to "reset" prior to the impact of the incorrect EIP2200 implementation.
 
-There seem to be two major, sometimes contradictory, philosophies about ETC testnets.
+There seem to be two major, sometimes contradictory, philosophies about ETC testnets:
 
 A. Testnets are a public service; a place for ETC-based dapp developers to try out their stuff in public.
 

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -61,4 +61,9 @@ We can follow the logic of B: Testnets-as-test, and not only resolve the issue o
 
 ### Implementation
 
+N/A
+
 ### Copyright/Licensing
+
+This work is licensed under [Apache License, Version
+2.0](http://www.apache.org/licenses/).

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -2,7 +2,7 @@
 ecip: 1087
 title: ECIP1061/ECIP1078/ECIP1086 on Mordor Testnet (with rollback)
 discussions-to: TBD
-status: Draft
+status: Withdrawn
 type: Standards Track (Core)
 created: 2020-02-20
 license: Apache-2.0

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -12,24 +12,26 @@ license: Apache-2.0
 
 Don't touch Kotti; allow ECIP1061, ECIP1078, and ECIP1086 (EIP2200, EIP2200Disable) to continue as specified and implemented there.
 
-Rollback Mordor to 750000 (3507 block prior to ECIP1061 activation), with ECIP1078 activation at block 778507 (same as ECIP1061).
+Rollback Mordor to 750000 (3507 blocks prior to ECIP1061 activation), with ECIP1078 activation at block 778507 (same as ECIP1061).
 
 ### Motivation
 
 ECIP1061 specifies a hard fork "Aztlan" for ETC networks. (google it)
+
 ECIP1078 specifies a hard fork "Phoenix" for ETC Networks (discussions here: https://github.com/ethereumclassic/ECIPs/issues/262).
 
-ECIP1061 includes EIP2200.
+ECIP1061 enables EIP2200.
+
 ECIP1078 disables EIP2200
 
 EIP2200 was incorrectly implemented in ethereum/go-ethereum, etclabscore/multi-geth, multi-geth/multi-geth, and paritytech/parityethereum clients, which together compose the lion's share of ETC network providership.
 EIP2200 has since been (simply) corrected (in all impacted providers AFAIK).
 
-ECIP1061 and ECIP1078 have equal activation block numbers on mainnet.
-But, ECIP1061 has already been activated on testnets, while ECIP1078, with a later testnet activation values, is not yet enabled on testnets.
+ECIP1061 and ECIP1078 have equal activation block numbers on mainnet (10_500_839).
+But ECIP1061 has already been activated on testnets, while ECIP1078, with a later testnet activation, is not yet enabled on the testnets.
 
 This means that an incorrect implementation of EIP2200 is live on testnets.
-This means that protocol providers publishing releasing which include ECIP1078 for testnets are faced with a dilemma:
+This means that protocol providers publishing releases which include ECIP1078 for testnets are faced with a dilemma:
 
 - Don't correct EIP2200 before the testnets ECIP1078 fork.
 - Do correct EIP2200 before the fork, but follow specification (ECIP1086) to "allow" the incorrect EIP2200 implementation.
@@ -38,18 +40,23 @@ This means that protocol providers publishing releasing which include ECIP1078 f
 There seem to be two major, sometimes contradictory, philosophies about ETC testnets.
 
 A. Testnets are a public service; a place for ETC-based dapp developers to try out their stuff in public.
+
 B. Testnets are a public test; a place to demonstrate network feature acceptance before equivalent changes risk actual value on ETC mainnet.
 
 ### Specification
 
-Accept and include ECIP1086 on Kotti testnet. It's a PoA network, so it doesn't mirror ETC mainnet in the first place since it uses different consensus rules.
+Accept and include ECIP1086 on Kotti testnet. This leaves ECIP1061, ECIP1078, and the current proposal for handling the EIP2200 in/correction as-is and unchanged. 
 
 Change Mordor testnet ECIP1078 activation number to 778507. This will place ECIP1061 and ECIP1078 activation at equal blocks, and they will activate simulaneously, just like they are scheduled to on mainnet.
 Reset Mordor testnet back to block 775000 (3507 blocks prior to its ECIP1061 -- and, as proposed, ECIP1078 -- activation).
 
 ### Rationale
 
-This allows one testnet (Kotti, the one already consensus-different from mainnet) to continue as an unedited public resource, and the other (Mordor, the Proof of Work one) to simulate the feature and feature-activation behavior of mainnet equivalently.
+Kotti is a PoA network, so it doesn't simulate (_ie_ test) ETC mainnet in the first place (at least not _well_) since it uses different consensus rules. 
+If it is a public simulation and test of ETC mainnet, it isn't a good one. So we can follow the logic of A: Testnets-as-service.
+
+Mordor is a PoW network, so is is a pretty good simulator of ETC mainnet. 
+We can follow the logic of B: Testnets-as-test, and not only resolve the issue of EIP2200 correction, but improve the network's simulation of mainnet activation for ECIP1061 and ECIP1078.
 
 ### Implementation
 

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -1,0 +1,56 @@
+---
+ecip: 1087
+title: EIP2200 Correction on Mordor Testnet
+discussions-to: TBD
+status: Draft
+type: Standards Track (Core)
+created: 2020-02-20
+license: Apache-2.0
+---
+
+### Abstract
+
+Don't touch Kotti; allow ECIP1061, ECIP1078, and ECIP1086 (EIP2200, EIP2200Disable) to continue as specified and implemented there.
+
+Rollback Mordor to 750000, activate ECIP1078 at block 778508.
+
+### Motivation
+
+ECIP1061 specifies a hard fork "Aztlan" for ETC networks. (google it)
+ECIP1078 specifies a hard fork "Phoenix" for ETC Networks (discussions here: https://github.com/ethereumclassic/ECIPs/issues/262).
+
+ECIP1061 includes EIP2200.
+ECIP1078 disables EIP2200
+
+EIP2200 was incorrectly implemented in ethereum/go-ethereum, etclabscore/multi-geth, multi-geth/multi-geth, and paritytech/parityethereum clients, which together compose the lion's share of ETC network providership.
+EIP2200 has since been (simply) corrected (in all impacted providers AFAIK).
+
+ECIP1061 and ECIP1078 have equal activation block numbers on mainnet.
+But, ECIP1061 has already been activated on testnets, while ECIP1078, with a later testnet activation values, is not yet enabled on testnets.
+
+This means that an incorrect implementation of EIP2200 is live on testnets.
+This means that protocol providers publishing releasing which include ECIP1078 for testnets are faced with a dilemma:
+
+- Don't correct EIP2200 before the testnets ECIP1078 fork.
+- Do correct EIP2200 before the fork, but follow specification (ECIP1086) to "allow" the incorrect EIP2200 implementation.
+- Do correct EIP2200 before the fork, but rollback the effected testnets to "reset" prior to the impact of the incorrect EIP2200 implementation.
+
+There seem to be two major, sometimes contradictory, philosophies about ETC testnets.
+
+A. Testnets are a public service; a place for ETC-based dapp developers to try out their stuff in public.
+B. Testnets are a public test; a place to demonstrate network feature acceptance before equivalent changes risk actual value on ETC mainnet.
+
+### Specification
+
+Accept and include ECIP1086 on Kotti testnet. It's a PoA network, so it doesn't mirror ETC mainnet in the first place since it uses different consensus rules.
+
+Change Mordor testnet ECIP1078 activation number to 778507. This will place ECIP1061 and ECIP1078 activation at equal blocks, and they will activate simulaneously, just like they are scheduled to on mainnet.
+Reset Mordor testnet back to block 775000 (3507 blocks prior to its ECIP1061 -- and, as proposed, ECIP1078 -- activation).
+
+### Rationale
+
+This allows one testnet (Kotti, the one already consensus-different from mainnet) to continue as an unedited public resource, and the other (Mordor, the Proof of Work one) to simulate the feature and feature-activation behavior of mainnet equivalently.
+
+### Implementation
+
+### Copyright/Licensing

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -1,6 +1,6 @@
 ---
 ecip: 1087
-title: EIP2200 Correction on Mordor Testnet
+title: ECIP1061/ECIP1078/ECIP1086 on Mordor Testnet (with rollback)
 discussions-to: TBD
 status: Draft
 type: Standards Track (Core)

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -30,7 +30,7 @@ EIP2200 has since been (simply) corrected (in all impacted providers AFAIK).
 ECIP1061 and ECIP1078 have equal activation block numbers on mainnet (10_500_839).
 But ECIP1061 has already been activated on testnets, while ECIP1078, with a later testnet activation, is not yet enabled on the testnets.
 
-This means that an incorrect implementation of EIP2200 is live on testnets.
+This means that an incorrect (and mainnet irrelevant) implementation of EIP2200 is live on testnets.
 This means that protocol providers publishing releases which include ECIP1078 for testnets are faced with a dilemma:
 
 - Don't correct EIP2200 before the testnets ECIP1078 fork.

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -55,7 +55,7 @@ Reset Mordor testnet back to block 775000 (3507 blocks prior to its ECIP1061 -- 
 Kotti is a PoA network, so it doesn't simulate (_ie_ test) ETC mainnet in the first place (at least not _well_) since it uses different consensus rules. 
 If it is a public simulation and test of ETC mainnet, it isn't a good one. So we can follow the logic of A: Testnets-as-service.
 
-Mordor is a PoW network, so is is a pretty good simulator of ETC mainnet. 
+Mordor is a PoW network, making it a better simulator of ETC mainnet. 
 We can follow the logic of B: Testnets-as-test, and not only resolve the issue of EIP2200 correction, but improve the network's simulation of mainnet activation for ECIP1061 and ECIP1078.
 
 ### Implementation

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 
 Don't touch Kotti; allow ECIP1061, ECIP1078, and ECIP1086 (EIP2200, EIP2200Disable) to continue as specified and implemented there.
 
-Rollback Mordor to 750000, activate ECIP1078 at block 778507.
+Rollback Mordor to 750000 (3507 block prior to ECIP1061 activation), with ECIP1078 activation at block 778507 (same as ECIP1061).
 
 ### Motivation
 

--- a/_specs/ecip-1087.md
+++ b/_specs/ecip-1087.md
@@ -6,6 +6,7 @@ status: Draft
 type: Standards Track (Core)
 created: 2020-02-20
 license: Apache-2.0
+requires: ECIP1061 ECIP1078 ECIP1086
 ---
 
 ### Abstract


### PR DESCRIPTION
### Abstract

Don't touch Kotti; allow ECIP1061, ECIP1078, and ECIP1086 (EIP2200, EIP2200Disable) to continue as specified and implemented there.

Set Mordor ECIP1078 activation to 778507 (equivalent to ECIP1061), and rollback to 750000.

### Rationale

Kotti is a PoA network, so it doesn't simulate (ie test) ETC mainnet in the first place (at least not well) since it uses different consensus rules. If it is a public simulation and test of ETC mainnet, it isn't a good one. So we can follow the logic of A: Testnets-as-service.

Mordor is a PoW network, so is is a pretty good simulator of ETC mainnet. We can follow the logic of B: Testnets-as-test, and not only resolve the issue of EIP2200 correction, but improve the network's simulation of mainnet activation for ECIP1061 and ECIP1078.

---

Rendered: https://github.com/meowsbits/ECIPs/blob/feat/ecip1087/_specs/ecip-1087.md