### PR TITLE
ECIP-1061: Move Aztlan to Phoenix block on Mordor; ECIP-1086 Last Call

### DIFF
--- a/_specs/ecip-1061.md
+++ b/_specs/ecip-1061.md
@@ -31,9 +31,9 @@ _Istanbul_ hardforks. The proposed changes for Ethereum Classic's _Aztlán_ upgr
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- `778_507` on Mordor Classic PoW-testnet (activated on Jan 30th, 2020)
-- `2_058_191` on Kotti Classic PoA-testnet (approx Feb 12th, 2020)
-- `10_500_839` on Ethereum Classic PoW-mainnet (approx Jun 10th, 2020)
+- `976_231` on Mordor Classic PoW-testnet (March 4th, 2020)
+- `2_058_191` on Kotti Classic PoA-testnet (Feb 12th, 2020)
+- `10_500_839` on Ethereum Classic PoW-mainnet (Jun 10th, 2020)
 
 For more information on the opcodes and their respective EIPs and implementations, please see the _Specification_
 section of this document.

--- a/_specs/ecip-1086.md
+++ b/_specs/ecip-1086.md
@@ -2,7 +2,8 @@
 lang: en
 ecip: 1086
 title: SLOAD Gas Patch for the Classic Testnets
-status: Draft
+status: Last Call
+review-period-end: 2020-02-29
 type: Standards Track
 category: Core
 author: Talha Cross <no-reply@soc1.cz>
@@ -38,7 +39,7 @@ A subsequent protocol upgrade disabling [EIP-2200](https://eips.ethereum.org/EIP
 
 This document proposes the following `BLOCK_NUMBER` at which to implement these changes in the Classic test networks:
 
-- `778_507` on _Mordor_ Classic PoW-testnet (Jan 30th, 2020)
+- Never on _Mordor_ Classic PoW-testnet which will be reverted in favor of testing a proper _Phoenix_ transition.
 - `2_058_191` on _Kotti_ Classic PoA-testnet (Feb 12th, 2020)
 
 


### PR DESCRIPTION
The rationale is taken from #295 

* revert mordor and have a proper phoenix + aztlan hardfork
* keep kotti with ecip-1086 #293 

cc @meowsbits 