### PR TITLE
reject aztlan and pull phoenix

### DIFF
--- a/_specs/ecip-1061.md
+++ b/_specs/ecip-1061.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1061
 title: Aztlán EVM and Protocol Upgrades (Yingchun Edition)
-status: Accepted
+status: Rejected
 type: Meta
 author: Talha Cross (@soc1c), Wei Tang (@sorpaas)
 created: 2019-06-06
@@ -31,9 +31,9 @@ _Istanbul_ hardforks. The proposed changes for Ethereum Classic's _Aztlán_ upgr
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- `778_507` on Mordor Classic PoW-testnet (activated on Jan 30th, 2020)
-- `2_058_191` on Kotti Classic PoA-testnet (approx Feb 12th, 2020)
-- `10_500_839` on Ethereum Classic PoW-mainnet (approx Jun 10th, 2020)
+- ~~`778_507` on Mordor Classic PoW-testnet (activated on Jan 30th, 2020)~~
+- ~~`2_058_191` on Kotti Classic PoA-testnet (approx Feb 12th, 2020)~~
+- ~~`10_500_839` on Ethereum Classic PoW-mainnet (approx Jun 10th, 2020)~~
 
 For more information on the opcodes and their respective EIPs and implementations, please see the _Specification_
 section of this document.

--- a/_specs/ecip-1078.md
+++ b/_specs/ecip-1078.md
@@ -3,8 +3,7 @@ lang: en
 ecip: 1078
 title: Phoenix EVM and Protocol Upgrades ("Aztlán fix")
 author: Bob Summerwill (@bobsummerwill)
-status: Last Call
-review-period-end: 2020-03-30
+status: Rejected
 type: Meta
 created: 2020-01-19
 license: Apache-2.0
@@ -39,9 +38,9 @@ would result in protocol changes which met the original intent.
 
 This document proposes the following blocks at which to implement these changes in the Classic networks:
 
-- `976_231` on Mordor Classic PoW-testnet (approx March 4th, 2020)
-- `2_208_203` on Kotti Classic PoA-testnet (approx March 11st, 2020)
-- `10_500_839` on Ethereum Classic PoW-mainnet (approx June 10th, 2020)
+- ~~`976_231` on Mordor Classic PoW-testnet (approx March 4th, 2020)~~
+- ~~`2_208_203` on Kotti Classic PoA-testnet (approx March 11st, 2020)~~
+- ~~`10_500_839` on Ethereum Classic PoW-mainnet (approx June 10th, 2020)~~
 
 At HARD_FORK_BLOCK, apply the following changes:
 

--- a/_specs/ecip-1086.md
+++ b/_specs/ecip-1086.md
@@ -38,8 +38,8 @@ A subsequent protocol upgrade disabling [EIP-2200](https://eips.ethereum.org/EIP
 
 This document proposes the following `BLOCK_NUMBER` at which to implement these changes in the Classic test networks:
 
-- `778_507` on _Mordor_ Classic PoW-testnet (Jan 30th, 2020)
-- `2_058_191` on _Kotti_ Classic PoA-testnet (Feb 12th, 2020)
+- ~~`778_507` on _Mordor_ Classic PoW-testnet (Jan 30th, 2020)~~
+- ~~`2_058_191` on _Kotti_ Classic PoA-testnet (Feb 12th, 2020)~~
 
 
 ### Rationale

--- a/_specs/ecip-1086.md
+++ b/_specs/ecip-1086.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1086
 title: SLOAD Gas Patch for the Classic Testnets
-status: Draft
+status: Reject
 type: Standards Track
 category: Core
 author: Talha Cross <no-reply@soc1.cz>


### PR DESCRIPTION
due to the multiple issues disclosed with aztlan and phoenix not being a sufficient fix and both testnets being broken, this pull request proposes to reject ecips-1061, 1078, 1086 due to security and stability concerns and to move on with writing a phoenix proposal from scratch. 

accepting this pull request requires community consensus in a publicly announced call.