### PR TITLE
ECIP-0001: Fixed url capitalization - added language to include controversies

### DIFF
--- a/_specs/ecip-0001.md
+++ b/_specs/ecip-0001.md
@@ -203,7 +203,7 @@ For Meta or Informational ECIPs:
 WIP -> DRAFT -> LAST CALL -> ACTIVE
 ````
 
-However, core developers and editors can decide to move ECIPs back to previous statuses after the fact, or to `Rejected` or `Withdrawn` status at their discretion provided there is reasonable cause, e.g. a major, but correctable, flaw was found in the ECIP, or a major but not correctable flaw was found in the ECIP.
+However, core developers and editors can decide to move ECIPs back to previous statuses after the fact, or to `Rejected` or `Withdrawn` status, at their discretion provided there is reasonable cause, including but not limited to, a major, but correctable, flaw was found in the ECIP, a major but not correctable flaw was found in the ECIP.
 
 Champions of an ECIP may decide on their own to change the status between `Draft`, `Deferred`, or `Withdrawn`.
 

--- a/_specs/ecip-0001.md
+++ b/_specs/ecip-0001.md
@@ -79,11 +79,12 @@ A good reason to transfer ownership is because the original author no longer has
 
 The current ECIP editors are:
 
+* Zachary Belford (@BelfordZ)
 * Mr. Meows D. Bits (@meowsbits)
 * Cody Burns (@realcodywburns)
 * Talha Cross (@soc1c)
 * Yaz Khoury (@YazzyYaz)
-* Zachary Belford (@BelfordZ)
+* Wei Tang (@sorpaas)
 
 ## ECIP Editor Responsibilities & Workflow
 

--- a/_specs/ecip-0001.md
+++ b/_specs/ecip-0001.md
@@ -203,7 +203,7 @@ For Meta or Informational ECIPs:
 WIP -> DRAFT -> LAST CALL -> ACTIVE
 ````
 
-However, core developers and editors can decide to move ECIPs back to previous statuses after the fact, or to `Rejected` or `Withdrawn` status, at their discretion provided there is reasonable cause, including but not limited to, a major, but correctable, flaw was found in the ECIP, a major but not correctable flaw was found in the ECIP.
+However, core developers and editors can decide to move ECIPs back to previous statuses after the fact, or to `Rejected` or `Withdrawn` status, at their discretion provided there is reasonable cause, including but not limited to, a major, but correctable, flaw was found in the ECIP, or a major but not correctable flaw was found in the ECIP.
 
 Champions of an ECIP may decide on their own to change the status between `Draft`, `Deferred`, or `Withdrawn`.
 


### PR DESCRIPTION
• ECIP -> ecip

• Added language "including, but not limited to" in the phrase that clarifies that devs/editors can change ECIPs to previous statuses in the case in the examples but also if other major events occur, such as the recent ProgPow controversy after EIP-1057 was moved to accepted. The text modified was:

"However, core developers and editors can decide to move ECIPs back to previous statuses after the fact, or to `Rejected` or `Withdrawn` status, at their discretion provided there is reasonable cause, **including but not limited to,** a major, but correctable, flaw was found in the ECIP, a major but not correctable flaw was found in the ECIP."