### PR TITLE
Integrating ecip-0001 into ecip-1000

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -5,7 +5,7 @@ title: ECIP Process
 status: Active
 type: Meta
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/58
-author: Wei Tang (@sorpaas)
+author: Wei Tang (@sorpaas) & Donald McIntyre (@TokenHash)
 created: 2017-06-29
 license: Apache-2
 ---
@@ -14,13 +14,19 @@ license: Apache-2
 
 An Ethereum Classic Improvement Proposal (ECIP) is a design document providing information to the Ethereum Classic community, or describing a new feature for Ethereum Classic or its processes or environment. The ECIP should provide a concise technical specification of the feature and a rationale for the feature.
 
-We intend ECIPs to be the primary mechanism for proposing new features, for collecting community input on an issue, and for documenting the design decisions that have gone into Ethereum Classic. The **ECIP author** is responsible for building consensus within the community and documenting dissenting opinions.
+We intend ECIPs to be the primary mechanism for proposing new features, for collecting ecosystem input on an issue, and for documenting the design decisions that have gone into Ethereum Classic. The **ECIP author** is responsible for building consensus within the community and documenting dissenting opinions.
 
-Because the ECIPs are maintained as text files in a versioned repository, their revision history is the historical record of the feature proposal.
+Because ECIPs are maintained as text files in a versioned repository, their revision history is the historical record of the feature proposal.
+
+This ECIP process has the purpose of making proposals and maintaining the Ethereum Classic protocol, **it is not a governance system nor a constitution**.
 
 # Copyright
 
 This ECIP is licensed Apache-2, originally by [Luke Dashjr](https://github.com/luke-jr) under BSD 2-clause license.
+
+# Precedents
+
+This ECIP process has the precedents of the [Bitcoin BIP](https://github.com/bitcoin/bips/blob/master/bip-0002.mediawiki) and the [Ethereum EIP](https://github.com/ethereum/EIPs) processes.
 
 # ECIP Workflow
 
@@ -34,7 +40,7 @@ Additionally, many ideas have been brought forward for changing Ethereum Classic
 
 ## Steps
 
-**1:** The first step should be to search past discussions to see if an idea has been considered before, and if so, what issues arose in its progression.
+**1)** The first step should be to search past discussions to see if an idea has been considered before, and if so, what issues arose in its progression.
 
 After investigating past work, the best way to proceed is by posting about the new idea to the [Ethereum Classic Discord #ecips Channel](https://discord.gg/8q8xRtQ).
 
@@ -44,13 +50,13 @@ Asking the Ethereum Classic community first if an idea is original helps prevent
 
 It also helps to make sure the idea is applicable to the entire community and not just the author. Just because an idea sounds good to the author does not mean it will work for most people in most areas where Ethereum Classic is used.
 
-**2:** Once the champion has asked the Ethereum Classic community as to whether an idea has any chance of acceptance, a **draft ECIP** should be submitted to the [ECIPs git repository](https://github.com/ethereumclassic/ECIPs) as a pull request. This gives the author a chance to flesh out the draft ECIP to make it properly formatted, of high quality, and to address additional concerns about the proposal. This draft must be written in ECIP style as described below, and named with an alias such as "ecip-johndoe-infinitecoins" until an editor has assigned it an ECIP number (authors MUST NOT self-assign ECIP numbers).
+**2)** Once the champion has asked the Ethereum Classic community as to whether an idea has any chance of acceptance, a **draft ECIP** should be submitted to the [ECIPs git repository](https://github.com/ethereumclassic/ECIPs) as a pull request. This gives the author a chance to flesh out the draft ECIP to make it properly formatted, of high quality, and to address additional concerns about the proposal. This draft must be written in ECIP style as described below, and named with an alias such as "ecip-johndoe-infinitecoins" until an editor has assigned it an ECIP number (authors MUST NOT self-assign ECIP numbers).
 
 ECIP authors **are responsible for collecting community feedback** on both the initial idea and the ECIP before submitting it for review. However, wherever possible, long open-ended discussions on public groups or mailing lists should be avoided. Strategies to keep the discussions efficient include: setting up a separate SIG mailing list for the topic, having the ECIP author accept private comments in the early design phases, setting up a wiki page or git repository, etc. ECIP authors should use their discretion here.
 
-It is highly recommended that **a single ECIP contain a single key proposal or new idea**. The more focused the ECIP, the more successful it tends to be. If in doubt, split your ECIP into several well-focused ones. Please check out the ECIPs in this repository and search for similar ones that have already been created.
+It is highly recommended that **a single ECIP contain a single key proposal or new idea**. The more focused the ECIP, the more successful it tends to be. If in doubt, split your ECIP into several well-focused ones.
 
-**3:** When the ECIP draft is complete, an ECIP editor will assign the ECIP a number, label it as Standards Track, Informational, or Process, and merge the pull request to the ECIPs git repository.
+**3)** When the ECIP draft is complete, an ECIP editor will assign the ECIP a number, label it as Standards Track, Informational, or Process, and merge the pull request to the ECIPs git repository.
 
 The ECIP editor will not unreasonably reject an ECIP.
 
@@ -58,7 +64,7 @@ Reasons for rejecting ECIPs include duplication of effort, disregard for formatt
 
 For a ECIP to be accepted it must meet certain minimum criteria. It must be a clear and complete description of the proposed enhancement. The enhancement must represent a net improvement. The proposed implementation, if applicable, must be solid and must not complicate the protocol unduly.
 
-**4:** During the life cycle of the ECIP, the author may update the draft as necessary in the git repository. **Updates to drafts should also be submitted by the author as pull requests.**
+**4)** During the life cycle of the ECIP, the author may update the draft as necessary in the git repository. **Updates to drafts should also be submitted by the author as pull requests.**
 
 ## Transferring ECIP Ownership
 
@@ -70,14 +76,14 @@ A good reason to transfer ownership is because the original author no longer has
 
 ## ECIP Editors
 
-The current ECIP editors are:
+The current ECIP editors in alphabetical order are:
 
-* Wei Tang (@sorpaas)
+* Zachary Belford (@BelfordZ)
 * Mr. Meows D. Bits (@meowsbits)
 * Cody Burns (@realcodywburns)
 * Talha Cross (@soc1c)
 * Yaz Khoury (@YazzyYaz)
-* Zachary Belford (@BelfordZ)
+* Wei Tang (@sorpaas)
 
 ## ECIP Editor Responsibilities & Workflow
 
@@ -87,7 +93,7 @@ ECIP editors are intended to fulfill administrative and editorial responsibiliti
 
 ### Steps
 
-**1:** Each new ECIP should first be submitted as a **"pull request"** to the [ECIPs git repository](https://github.com/ethereumclassic/ECIPs). Then, an editor does the following:
+**1)** Each new ECIP should first be submitted as a **"pull request"** to the [ECIPs git repository](https://github.com/ethereumclassic/ECIPs). Then, an editor does the following:
 
 * Read the ECIP to check if it is ready: sound and complete. The ideas must make technical sense, even if it doesn't seem likely to be accepted.
 * The title should accurately describe the content.
@@ -95,9 +101,9 @@ ECIP editors are intended to fulfill administrative and editorial responsibiliti
 * The defined Layer header must be correctly assigned for the given specification.
 * Licensing terms must be acceptable for ECIPs.
 
-**2:** If the ECIP isn't ready, the editor will send it back to the author for revision with specific instructions.
+**2)** If the ECIP isn't ready, the editor will send it back to the author for revision with specific instructions.
 
-**3:** Once the ECIP is ready, the ECIP editor will:
+**3)** Once the ECIP is ready, the ECIP editor will:
 
 * Assign a ECIP number in the pull request.
 * Merge the pull request when it is ready.
@@ -172,7 +178,7 @@ There are three types of ECIP:
   - **Networking** - improvements to networking protocol specifications.
   - **Interface** - improvements around client [API/RPC] specifications and standards, and also certain language-level standards like method names  and contract ABIs.
   - **ECBP (Ethereum Classic Best Practice)** - application-level standards and conventions, including contract standards such as token standards, name registries, URI schemes, library/package formats, and wallet formats.
-- A **Meta ECIP** describes a **process** surrounding Ethereum Classic or proposes a change to a process (or an event like the next hard fork). Process ECIPs are like Standard Track ECIPs, but apply to areas other than the Ethereum Classic protocol itself. They may propose an implementation, but not to Ethereum Classic's codebase; they often require community consensus; unlike Informational ECIPs, they are more than recommendations, and users are typically not free to ignore them. Examples include procedures, guidelines, changes to the decision-making process (e.g. this ECIP-1000 process document), and changes to the tools or environment used in Ethereum Classic development. If a Meta ECIP is for a hard fork, changes are to be updated with PRs to existing Meta ECIPs. *Any meta-ECIP is also considered a Process ECIP.*
+- A **Meta ECIP** describes a **process** surrounding Ethereum Classic or proposes a change to (or an event in) a process. Process ECIPs are like Standard Track ECIPs, but apply to areas other than the Ethereum Classic protocol itself. They may propose an implementation, but not to Ethereum Classic's codebase; they often require community consensus; unlike Informational ECIPs, they are more than recommendations, and users are typically not free to ignore them. Examples include procedures, guidelines, changes to the decision-making process (e.g. this ECIP-0001 process document), and changes to the tools or environment used in Ethereum Classic development. *Any meta-ECIP is also considered a Process ECIP.*
 - An **Informational ECIP** describes an Ethereum Classic design issue, or provides general guidelines or information to the Ethereum Classic community, but does not propose a new feature. Informational ECIPs do not necessarily represent Ethereum Classic community consensus or a recommendation, so users and implementors are free to ignore Informational ECIPs or follow their advice.
 
 It is highly recommended that a single ECIP contain a single key proposal or new idea. The more focused the ECIP, the more successful it tends to be. A change to one client doesn't require an ECIP; a change that affects multiple clients, or defines a standard for multiple apps to use, does.
@@ -183,9 +189,21 @@ An ECIP must meet certain minimum criteria. It must be a clear and complete desc
 
 ### Specification
 
-The typical paths of the status of ECIPs are as follows:
+The typical status lifecycles of successful ECIP types, from pull requests to merged and fully processed or implemented, are as follows:
 
-![ECIP process](../assets/ecip-1000/process.png)
+For Standard Track ECIPs: 
+
+```
+WIP -> DRAFT -> LAST CALL -> ACCEPTED -> FINAL
+```
+
+For Meta or Informational ECIPs: 
+
+```
+WIP -> DRAFT -> LAST CALL -> ACTIVE
+````
+
+However, core developers and editors can decide to move ECIPs back to previous statuses after the fact, or to `Rejected` or `Withdrawn` status, at their discretion provided there is reasonable cause, including but not limited to, a major, but correctable, flaw was found in the ECIP, or a major but not correctable flaw was found in the ECIP.
 
 Champions of an ECIP may decide on their own to change the status between `Draft`, `Deferred`, or `Withdrawn`.
 
@@ -201,7 +219,7 @@ When a `Final` ECIP is no longer relevant, its status may be changed to `Replace
 
 Some Informational ECIPs, which are considered process ECIPs, may also be moved to a status of `Active` instead of `Final` if they are never meant to be completed, e.g. this [ECIP-1000.](./ecip-1000.md)
 
-`Draft` ECIPs which may be in a very early stage may be entered as `WIP` ECIPs, which means they are a work in progress.
+`Draft` ECIPs which may be in a very early stage may be entered as `WIP` pull requests, which means they are a work in progress. However, `WIP` ECIP pull requests may not be merged into the ECIP repository unless authors feel confident enough about their proposals and moved them to `Draft` status. 
 
 A process ECIP may change status from `Draft` to `Final` when it achieves rough consensus on the discussion process. Such a proposal is said to have rough consensus if it has been open to discussion on the development calls, Discord channel, other groups or the mailing list for at least one month, and no person maintains any unaddressed substantiated objections to it. Addressed or obstructive objections may be ignored/overruled by general agreement that they have been sufficiently addressed, but clear reasoning must be given in such circumstances.
 
@@ -303,7 +321,7 @@ For example, a preamble might include the following License header:
 
 In this case, the ECIP text is fully licensed under both the OSI-approved BSD 2-clause license as well as the GNU All-Permissive License, and anyone may modify and redistribute the text provided they comply with the terms of *either* license. In other words, the license list is an "OR choice", not an "AND also" requirement.
 
-It is also possible to license source code differently from the ECIP text. A optional License-Code header is placed after the License header. Again, each license must be referenced by their respective abbreviation given below.
+It is also possible to license source code differently from the ECIP text. An optional License-Code header is placed after the License header. Again, each license must be referenced by their respective abbreviation given below.
 
 For example, a preamble specifying the optional License-Code header might look like:
 
@@ -320,7 +338,7 @@ For a later version (eg, GPL 3.0), you would increase the version number (and re
     License-Code: GPL-3.0   # This refers to GPL v3.0 *only*, no later license versions are acceptable.
     License-Code: GPL-3.0+  # This refers to GPL v3.0 *or later*.
 
-In the event that the licensing for the text or code is too complicated to express with a simple list of alternatives, the list should instead be replaced with the single term "Complex". In all cases, details of the licensing terms must be provided in the Copyright section of the ECIP.
+In the event that the licensing for the text or code is too complicated to express with a simple list of alternatives, the list should instead be replaced with the single term "Complex". In all cases, the details of the licensing terms must be provided in the Copyright section of the ECIP.
 
 ECIPs are not required to be *exclusively* licensed under approved terms, and may also be licensed under unacceptable licenses *in addition to* at least one acceptable license.
 In this case, only the acceptable license(s) should be listed in the License and License-Code headers.
@@ -352,6 +370,22 @@ In addition, it is recommended that literal code included in the ECIP be dual-li
 
 * Some ECIPs, especially consensus layer, may include literal code in the ECIP itself which may not be available under the exact license terms of the ECIP.
 * Despite this, not all software licenses would be acceptable for content included in ECIPs.
+
+# ECIP Process Code of Conduct
+
+## ECIP Participants Will Adhere to the Following
+
+1. Anyone can participate in the ECIP process as a competent developer, miner, validator, node operator, user, or any other prescribed participant or stakeholder.
+
+2. Within the ECIP documents and discussion pages, participants will conduct themselves professionally, will not abuse their privileges, if any, to obstruct or derail the process, will focus on ECIP issues, making sure their arguments are well founded, minimizing trolling, insulting or derogatory comments, and personal or political attacks.
+
+3. Participant privacy will be respected. Publishing other participant’s private information, such as a physical or email addresses, or real names, without their explicit permission is not allowed within the ECIP process nor in other public forums.
+
+4. Ethereum Classic organization owners on Github or other platforms in use, ECIP repo admins, and ECIP editors have the right and responsibility to remove ECIP participants of any kind, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this ECIP-0001 and Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Rationale
+
+The ECIP process, like any open source software development process or repository on Github or other platforms, has suffered the vulnerability of being taken over, obstructed, or tampered with by internal and external participants. Although in a permissionless open source system as ETC the ideal is to minimize rules and to be as open as possible, it is also important to protect participant privacy, have a professional proposal and discussion dynamic, and minimize obstructions and harassment. These goals help guarantee openness and maintain a high technical and knowledgeable set of participants in the process.
 
 # See Also
 


### PR DESCRIPTION
To make it easier to compare and move to active, I am integrating the changes I proposed in ecip-0001 into this ecip-1000:

• it leaves Sorpaas as editor
• it keeps the changes and additions to rules proposed in ecip-0001

In summary, the new text largely clarifies some aspects of ecip-1000 that were not explicit before.

The goal is to minimize discussions about "process" and focus on standards.