### PR TITLE
ECIP-1088: Withdraw Phoenix Protocol Upgrades

### DIFF
--- a/_specs/ecip-1088.md
+++ b/_specs/ecip-1088.md
@@ -2,8 +2,7 @@
 lang: en
 ecip: 1088
 title: Phoenix EVM and Protocol Upgrades
-status: Last Call
-review-period-end: 2020-03-31
+status: Withdrawn
 type: Meta
 author: /raw PONG _GHMoaCXLT (@q9f)
 created: 2020-02-24


### PR DESCRIPTION
The review period ended yesterday on March 31st, 2020.

I don't see enough community support and step down championing this protocol upgrade.