### PR TITLE
1091: forkid v2 (kotti fix)

### DIFF
--- a/_specs/ecip-1082.md
+++ b/_specs/ecip-1082.md
@@ -4,7 +4,7 @@ ecip: 1082
 title: Fork identifier (`forkid`) protocol fork list specification
 author: github.com/meowsbits
 status: Superseded
-superseded-by: 1090
+superseded-by: 1091
 type: Standards Track
 category: Networking
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/294
@@ -156,5 +156,4 @@ The Ethereum Classic disinflationary monetary policy is not considered a series 
 ### Implementation
 
 Respective reference implementations for `forkid` generation are documented in EIP-2124 and EIP-2364.
-
 

--- a/_specs/ecip-1082.md
+++ b/_specs/ecip-1082.md
@@ -3,7 +3,8 @@ lang: en
 ecip: 1082
 title: Fork identifier (`forkid`) protocol fork list specification
 author: github.com/meowsbits
-status: Final
+status: Superseded
+superseded-by: 1090
 type: Standards Track
 category: Networking
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/294

--- a/_specs/ecip-1090.md
+++ b/_specs/ecip-1090.md
@@ -1,6 +1,6 @@
 ---
 lang: en
-ecip: 1090
+ecip: 1091
 title: Fork identifier (`forkid`) protocol fork list specification v2
 author: github.com/meowsbits
 status: Active
@@ -161,4 +161,3 @@ At the time of last edit, client implementation tests may be found at:
 - 2020-06-03
   + Modify Kotti eligible fork specs, removing blocks 2M and 5M. Prior specifications were generated using a faulty chain configuration, which wrongly included these blocks. Rel https://github.com/goerli/testnet/pull/71.
     - This modification is the first of its kind within this document, and is the sole modification against the superseded [ECIP1082](https://ecips.ethereumclassic.org/ECIPs/ecip-1082).
-

--- a/_specs/ecip-1090.md
+++ b/_specs/ecip-1090.md
@@ -1,0 +1,159 @@
+---
+lang: en
+ecip: 1090
+title: Fork identifier (`forkid`) protocol fork list specification v2
+author: github.com/meowsbits
+status: Draft
+supersedes: 1082
+type: Standards Track
+category: Networking
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/294
+created: 2020-06-03
+license: Apache-2.0
+---
+
+### Abstract
+
+EIP-2124 (`forkid`) and EIP-2364 (`eth/64`) propose discovery protocol modifications which depend on lists of fork values. In case these changes are adopted and implemented on Ethereum Classic networks, this ECIP defines canonical lists of forks numbers for inclusion in the generation and validation steps of these "ForkID" schemes.
+
+- https://eips.ethereum.org/EIPS/eip-2124
+- https://eips.ethereum.org/EIPS/eip-2364
+
+This specification describes a set of forks which exclude TheDAO fork event block(s) from `forkid` calculations, as well as excluding all forthcoming `blockNumber % 5000000 == 0` blocks that, according to the algorithmdescribed in ECIP-1017 and enabled on ETC Mainnet and some testnets, will see reduced block reward values.
+
+> This version (v2) of the Ethereum Classic forkid specification corrects Kotti
+> forkid expectations. The derivation removes wrongly configured Ethash specifications
+> for the chain configuration, and in doing so removes two invalid forks from
+> the parameterized fork list.
+
+### Motivation
+
+Specify parameters for `forkid` generation and validation, so that in the case nodes on Ethereum Classic networks implement `eth/64`, they can do so in a consistent way.
+
+As documented in EIP-2364, implementation for `eth/64` does not demand consensus nor require any fork for node or network implementation.
+
+Notwithstanding, it would be good for Ethereum Classic networks and clients to be able to implement the protocol change, if they want, according to a standard specification. Failure for clients to agree on `forkid` implementation could result in difficulty discovering each other.
+
+### Specification
+
+#### Generally
+
+Don't include TheDAO fork blocks (eg. `1920000` on Mainnet, `1885000` on Morden) as a `forkid` parameter as specified in EIP-2124.
+
+Don't include any blocks subsequent and incidental to consensus-facing calculations according to accepted and implemented algorithms, eg. ECIP-1017.
+
+#### Applied
+
+The following data points are valid at time of writing (see ECIP's `created-at` metadata).
+
+##### Ethereum Classic Mainnet (ETC)
+
+- Genesis Hash: `0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3`
+- - Forks: `1150000`,`2500000`,`3000000`,`5000000`,`5900000`,`8772000`,`9573000`,`10500839`
+-
+- | Head Block Number | `FORK_HASH` | `FORK_NEXT` | RLP Encoded (Hex) |
+- | --- | --- | --- | --- |
+- | head=0 | FORK_HASH=fc64ec04 | FORK_NEXT=1150000 | c984fc64ec0483118c30 |
+- | head=1149999 | FORK_HASH=fc64ec04 | FORK_NEXT=1150000 | c984fc64ec0483118c30 |
+- | __head=1150000__ | FORK_HASH=97c2c34c | FORK_NEXT=2500000 | c98497c2c34c832625a0 |
+- | head=1150001 | FORK_HASH=97c2c34c | FORK_NEXT=2500000 | c98497c2c34c832625a0 |
+- | head=2499999 | FORK_HASH=97c2c34c | FORK_NEXT=2500000 | c98497c2c34c832625a0 |
+- | __head=2500000__ | FORK_HASH=db06803f | FORK_NEXT=3000000 | c984db06803f832dc6c0 |
+- | head=2500001 | FORK_HASH=db06803f | FORK_NEXT=3000000 | c984db06803f832dc6c0 |
+- | head=2999999 | FORK_HASH=db06803f | FORK_NEXT=3000000 | c984db06803f832dc6c0 |
+- | __head=3000000__ | FORK_HASH=aff4bed4 | FORK_NEXT=5000000 | c984aff4bed4834c4b40 |
+- | head=3000001 | FORK_HASH=aff4bed4 | FORK_NEXT=5000000 | c984aff4bed4834c4b40 |
+- | head=4999999 | FORK_HASH=aff4bed4 | FORK_NEXT=5000000 | c984aff4bed4834c4b40 |
+- | __head=5000000__ | FORK_HASH=f79a63c0 | FORK_NEXT=5900000 | c984f79a63c0835a06e0 |
+- | head=5000001 | FORK_HASH=f79a63c0 | FORK_NEXT=5900000 | c984f79a63c0835a06e0 |
+- | head=5899999 | FORK_HASH=f79a63c0 | FORK_NEXT=5900000 | c984f79a63c0835a06e0 |
+- | __head=5900000__ | FORK_HASH=744899d6 | FORK_NEXT=8772000 | c984744899d68385d9a0 |
+- | head=5900001 | FORK_HASH=744899d6 | FORK_NEXT=8772000 | c984744899d68385d9a0 |
+- | head=8771999 | FORK_HASH=744899d6 | FORK_NEXT=8772000 | c984744899d68385d9a0 |
+- | __head=8772000__ | FORK_HASH=518b59c6 | FORK_NEXT=9573000 | c984518b59c683921288 |
+- | head=8772001 | FORK_HASH=518b59c6 | FORK_NEXT=9573000 | c984518b59c683921288 |
+- | head=9572999 | FORK_HASH=518b59c6 | FORK_NEXT=9573000 | c984518b59c683921288 |
+- | __head=9573000__ | FORK_HASH=7ba22882 | FORK_NEXT=10500839 | c9847ba2288283a03ae7 |
+- | head=9573001 | FORK_HASH=7ba22882 | FORK_NEXT=10500839 | c9847ba2288283a03ae7 |
+- | head=10500838 | FORK_HASH=7ba22882 | FORK_NEXT=10500839 | c9847ba2288283a03ae7 |
+- | __head=10500839__ | FORK_HASH=9007bfcc | FORK_NEXT=0 | c6849007bfcc80 |
+- | head=10500840 | FORK_HASH=9007bfcc | FORK_NEXT=0 | c6849007bfcc80 |
+-
+-
+- ##### Kotti
+-
+- - Genesis Hash: `0x14c2283285a88fe5fce9bf5c573ab03d6616695d717b12a127188bcacfc743c4`
+- - Forks: `716617`,`1705549`,`2200013`
+-
+- | Head Block Number | `FORK_HASH` | `FORK_NEXT` | RLP Encoded (Hex) |
+- | --- | --- | --- | --- |
+- | head=0 | FORK_HASH=0550152e | FORK_NEXT=716617 | c9840550152e830aef49 |
+- | head=716616 | FORK_HASH=0550152e | FORK_NEXT=716617 | c9840550152e830aef49 |
+- | __head=716617__ | FORK_HASH=a3270822 | FORK_NEXT=1705549 | c984a3270822831a064d |
+- | head=716618 | FORK_HASH=a3270822 | FORK_NEXT=1705549 | c984a3270822831a064d |
+- | head=1705548 | FORK_HASH=a3270822 | FORK_NEXT=1705549 | c984a3270822831a064d |
+- | __head=1705549__ | FORK_HASH=8f3698e0 | FORK_NEXT=2200013 | c9848f3698e0832191cd |
+- | head=1705550 | FORK_HASH=8f3698e0 | FORK_NEXT=2200013 | c9848f3698e0832191cd |
+- | head=2200012 | FORK_HASH=8f3698e0 | FORK_NEXT=2200013 | c9848f3698e0832191cd |
+- | __head=2200013__ | FORK_HASH=6f402821 | FORK_NEXT=0 | c6846f40282180 |
+- | head=2200014 | FORK_HASH=6f402821 | FORK_NEXT=0 | c6846f40282180 |
+-
+-
+- ##### Mordor
+-
+- - Genesis Hash: `0xa68ebde7932eccb177d38d55dcc6461a019dd795a681e59b5a3e4f3a7259a3f1`
+- - Forks: `301243`,`999983`
+-
+- | Head Block Number | `FORK_HASH` | `FORK_NEXT` | RLP Encoded (Hex) |
+- | --- | --- | --- | --- |
+- | head=0 | FORK_HASH=175782aa | FORK_NEXT=301243 | c984175782aa830498bb |
+- | head=301242 | FORK_HASH=175782aa | FORK_NEXT=301243 | c984175782aa830498bb |
+- | __head=301243__ | FORK_HASH=604f6ee1 | FORK_NEXT=999983 | c984604f6ee1830f422f |
+- | head=301244 | FORK_HASH=604f6ee1 | FORK_NEXT=999983 | c984604f6ee1830f422f |
+- | head=999982 | FORK_HASH=604f6ee1 | FORK_NEXT=999983 | c984604f6ee1830f422f |
+- | __head=999983__ | FORK_HASH=f42f5539 | FORK_NEXT=0 | c684f42f553980 |
+- | head=999984 | FORK_HASH=f42f5539 | FORK_NEXT=0 | c684f42f553980 |
+-
+-
+- ##### Morden
+-
+- - Genesis Hash: `0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303`
+- - Forks: `494000`,`1783000`,`1915000`,`2000000`,`2300000`,`4729274`,`5000381`
+-
+- | Head Block Number | `FORK_HASH` | `FORK_NEXT` | RLP Encoded (Hex) |
+- | --- | --- | --- | --- |
+- | head=0 | FORK_HASH=417adbe7 | FORK_NEXT=494000 | c984417adbe7830789b0 |
+- | head=493999 | FORK_HASH=417adbe7 | FORK_NEXT=494000 | c984417adbe7830789b0 |
+- | __head=494000__ | FORK_HASH=aeb67dfb | FORK_NEXT=1783000 | c984aeb67dfb831b34d8 |
+- | head=494001 | FORK_HASH=aeb67dfb | FORK_NEXT=1783000 | c984aeb67dfb831b34d8 |
+- | head=1782999 | FORK_HASH=aeb67dfb | FORK_NEXT=1783000 | c984aeb67dfb831b34d8 |
+- | __head=1783000__ | FORK_HASH=6a495281 | FORK_NEXT=1915000 | c9846a495281831d3878 |
+- | head=1783001 | FORK_HASH=6a495281 | FORK_NEXT=1915000 | c9846a495281831d3878 |
+- | head=1914999 | FORK_HASH=6a495281 | FORK_NEXT=1915000 | c9846a495281831d3878 |
+- | __head=1915000__ | FORK_HASH=e893e32d | FORK_NEXT=2000000 | c984e893e32d831e8480 |
+- | head=1915001 | FORK_HASH=e893e32d | FORK_NEXT=2000000 | c984e893e32d831e8480 |
+- | head=1999999 | FORK_HASH=e893e32d | FORK_NEXT=2000000 | c984e893e32d831e8480 |
+- | __head=2000000__ | FORK_HASH=12a0ac82 | FORK_NEXT=2300000 | c98412a0ac8283231860 |
+- | head=2000001 | FORK_HASH=12a0ac82 | FORK_NEXT=2300000 | c98412a0ac8283231860 |
+- | head=2299999 | FORK_HASH=12a0ac82 | FORK_NEXT=2300000 | c98412a0ac8283231860 |
+- | __head=2300000__ | FORK_HASH=02a93060 | FORK_NEXT=4729274 | c98402a93060834829ba |
+- | head=2300001 | FORK_HASH=02a93060 | FORK_NEXT=4729274 | c98402a93060834829ba |
+- | head=4729273 | FORK_HASH=02a93060 | FORK_NEXT=4729274 | c98402a93060834829ba |
+- | __head=4729274__ | FORK_HASH=4802d0c7 | FORK_NEXT=5000381 | c9844802d0c7834c4cbd |
+- | head=4729275 | FORK_HASH=4802d0c7 | FORK_NEXT=5000381 | c9844802d0c7834c4cbd |
+- | head=5000380 | FORK_HASH=4802d0c7 | FORK_NEXT=5000381 | c9844802d0c7834c4cbd |
+- | __head=5000381__ | FORK_HASH=0b559b1d | FORK_NEXT=0 | c6840b559b1d80 |
+- | head=5000382 | FORK_HASH=0b559b1d | FORK_NEXT=0 | c6840b559b1d80 |
+-
+
+### Rationale
+
+The Ethereum Classic consensus protocol did not fork at block 1920000.
+
+The Ethereum Classic disinflationary monetary policy is not considered a series of forks, it is the natural "stepping" behavior of a deterministic algorithm.
+
+### Implementation
+
+Respective reference implementations for `forkid` generation are documented in EIP-2124 and EIP-2364.
+
+

--- a/_specs/ecip-1090.md
+++ b/_specs/ecip-1090.md
@@ -3,7 +3,7 @@ lang: en
 ecip: 1090
 title: Fork identifier (`forkid`) protocol fork list specification v2
 author: github.com/meowsbits
-status: Draft
+status: Active
 supersedes: 1082
 type: Standards Track
 category: ECBP

--- a/_specs/ecip-1090.md
+++ b/_specs/ecip-1090.md
@@ -6,7 +6,7 @@ author: github.com/meowsbits
 status: Draft
 supersedes: 1082
 type: Standards Track
-category: Networking
+category: ECBP
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/294
 created: 2020-06-03
 license: Apache-2.0
@@ -20,11 +20,6 @@ EIP-2124 (`forkid`) and EIP-2364 (`eth/64`) propose discovery protocol modificat
 - https://eips.ethereum.org/EIPS/eip-2364
 
 This specification describes a set of forks which exclude TheDAO fork event block(s) from `forkid` calculations, as well as excluding all forthcoming `blockNumber % 5000000 == 0` blocks that, according to the algorithmdescribed in ECIP-1017 and enabled on ETC Mainnet and some testnets, will see reduced block reward values.
-
-> This version (v2) of the Ethereum Classic forkid specification corrects Kotti
-> forkid expectations. The derivation removes wrongly configured Ethash specifications
-> for the chain configuration, and in doing so removes two invalid forks from
-> the parameterized fork list.
 
 ### Motivation
 
@@ -44,7 +39,7 @@ Don't include any blocks subsequent and incidental to consensus-facing calculati
 
 #### Applied
 
-The following data points are valid at time of writing (see ECIP's `created-at` metadata).
+The following data points are valid at time of last edit.
 
 ##### Ethereum Classic Mainnet (ETC)
 
@@ -156,4 +151,14 @@ The Ethereum Classic disinflationary monetary policy is not considered a series 
 
 Respective reference implementations for `forkid` generation are documented in EIP-2124 and EIP-2364.
 
+At the time of last edit, client implementation tests may be found at:
+- Core-Geth: https://github.com/etclabscore/core-geth/blob/master/core/forkid/forkid_test.go#L132, https://github.com/etclabscore/core-geth/blob/master/core/forkid/forkid_test.go#L322
+- Multi-Geth: https://github.com/etclabscore/core-geth/blob/master/core/forkid/forkid_test.go#L132
+- OpenEthereum: https://github.com/openethereum/openethereum/blob/master/ethcore/sync/src/chain/fork_filter.rs#L145
+
+### Change Log
+
+- 2020-06-03
+  + Modify Kotti eligible fork specs, removing blocks 2M and 5M. Prior specifications were generated using a faulty chain configuration, which wrongly included these blocks. Rel https://github.com/goerli/testnet/pull/71.
+    - This modification is the first of its kind within this document, and is the sole modification against the superseded [ECIP1082](https://ecips.ethereumclassic.org/ECIPs/ecip-1082).
 


### PR DESCRIPTION
This version of the Ethereum Classic forkid specification corrects Kotti
forkid expectations, superseding [ECIP1082](https://ecips.ethereumclassic.org/ECIPs/ecip-1082). The change removes wrongly configured Ethash specifications
for the chain configuration, and in doing so removes two invalid forks (2000000, 5000000) from
the parameterized fork list.

Please see Pull Requests referenced below for implementation.

_EDIT_: This ECIP also documents itself as an "Active" ECBP, allowing further edits as necessitated by future network protocol upgrades.
