### PR TITLE
MV Sorpaas from current to former ecip editor

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -70,14 +70,16 @@ A good reason to transfer ownership is because the original author no longer has
 
 ## ECIP Editors
 
-The current ECIP editors are:
+Current ECIP editors:
 
-* Wei Tang (@sorpaas)
 * Mr. Meows D. Bits (@meowsbits)
 * Cody Burns (@realcodywburns)
 * Talha Cross (@soc1c)
 * Yaz Khoury (@YazzyYaz)
 * Zachary Belford (@BelfordZ)
+
+Former ECIP editors:
+* Wei Tang (@sorpaas)
 
 ## ECIP Editor Responsibilities & Workflow
 


### PR DESCRIPTION
Moving Wei Tang (@sorpaas) from "current editors" to "former editors" to comply with their wish to disengage from Ethereum classic ecosystem. Reference: https://that.world/~classic/2020/06/10/deprecate/