### PR TITLE
Move ECIP-1043 DAG-Size Limit to Last Call

### DIFF
--- a/_specs/ecip-1043.md
+++ b/_specs/ecip-1043.md
@@ -3,7 +3,8 @@ lang: en
 ecip: 1043
 title: Fixed DAG limit restriction 
 author: Cody Burns <cody.w.burns@gmail.com>, Wolf Spraul <wolf@linzhi.io>
-status: Draft
+status: Last Call
+review-period-end: 2008-09-18
 type: Standards Track
 category: Core
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/11


### PR DESCRIPTION
as per #333 

please note, that this also requires the following action items to be worked on in the next 3 weeks:
- instead of freezing the DAG, just freeze the size and rotate parameters (Cody, James?)
- research current DAG size, project future DAG size, find suitable block number
