### PR TITLE
Move ECIP-1049 "Keccak256" to Last Call

### DIFF
--- a/_specs/ecip-1049.md
+++ b/_specs/ecip-1049.md
@@ -2,7 +2,8 @@
 lang: en
 ecip: 1049
 title: Change the ETC Proof of Work Algorithm to Keccak256
-status: Draft
+status: Last Call
+review-period-end: 2020-10-09
 type: Standards Track
 category: Core
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/13


### PR DESCRIPTION
as per #333 

together with #355

there will be a working group for SHA3 and Keccak256 formed asap, action items:
- working group to merge these proposals (Stevan & Alex)
- figure out and specify a proper transition from Ethash to the new algorithm

also, specifically, ECIP-1049 needs a lot of text work, please follow the ECIP-X template file.