### PR TITLE
ECIP 1043: Move to Replaced by 1099

### DIFF
--- a/_specs/ecip-1043.md
+++ b/_specs/ecip-1043.md
@@ -3,12 +3,12 @@ lang: en
 ecip: 1043
 title: Fixed DAG limit restriction 
 author: Cody Burns <cody.w.burns@gmail.com>, Wolf Spraul <wolf@linzhi.io>
-status: Last Call
-review-period-end: 2020-09-18
+status: Replaced
 type: Standards Track
 category: Core
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/11
 created: 2018-04-16
+superseded-by: 1099
 ---
 
 # ECIP-1043 – Fixed DAG limit restriction   


### PR DESCRIPTION
closes #11

decision from call #362 (13)

superseded by: 1099 #368 