### PR TITLE
doc: Remove Yaz as ECIP Editor

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -75,7 +75,6 @@ Current ECIP editors:
 * Mr. Meows D. Bits (@meowsbits)
 * Cody Burns (@realcodywburns)
 * Talha Cross (@soc1c)
-* Stevan Lohja (@stevanlohja)
 * Zachary Belford (@BelfordZ)
 
 Former ECIP editors:

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -75,11 +75,12 @@ Current ECIP editors:
 * Mr. Meows D. Bits (@meowsbits)
 * Cody Burns (@realcodywburns)
 * Talha Cross (@soc1c)
-* Yaz Khoury (@YazzyYaz)
+* Stevan Lohja (@stevanlohja)
 * Zachary Belford (@BelfordZ)
 
 Former ECIP editors:
 * Wei Tang (@sorpaas)
+* Yaz Khoury (@YazzyYaz)
 
 ## ECIP Editor Responsibilities & Workflow
 


### PR DESCRIPTION
I'm replacing myself with Stevan as ECIP Editor that is representing the ETC Cooperative.