### PR TITLE
1099: add additional comments to seedHash

### DIFF
--- a/_specs/ecip-1099.md
+++ b/_specs/ecip-1099.md
@@ -55,7 +55,10 @@ func calcEpoch(block uint64) int {
 }
 
 // seedHash is the seed to use for generating a verification cache and the
-// mining dataset.
+// mining dataset. The block number passed should represent an epoch boundary + 1
+// calculated as `block = epoch * [old/new]EpochLength + 1`
+// pre-1099: block = epoch * oldEpochLength + 1 OR block = currentBlock.number
+// 1099: block = epoch * newEpochLength + 1
 func seedHash(block uint64) []byte {
   seed := make([]byte, 32)
   if block < oldEpochLength {


### PR DESCRIPTION
Adds additional info to seedHash example, clarifying correct usage.

Motivated by: https://github.com/ethereumclassic/ECIPs/issues/397