### PR TITLE
ECIP-1102: Use The Etherplan Consensus Engine for Approving Proto Treasury Funding Proposals

### DIFF
--- a/_specs/ecip-1102.md
+++ b/_specs/ecip-1102.md
@@ -13,11 +13,11 @@ license: CC-BY-SA
 
 ### Abstract
 
-The Ethereum Classic (ETC) [Proto Treasury System](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1098.md) (p-ECTS) proposal suggests to direct 10% of the miner tax funds to a [Gitcoin grants](https://gitcoin.co/grants/) program. This ECIP proposes to direct those fund to an ETC community managed pool on the [Etherplan Consensus Engine](https://etherplan.com/2021/02/02/the-etherplan-consensus-engine/14989/) (ECE) dapp. The ECE is a system designed for decentralized groups of any kind to distribute funds using rough consensus.
+The Ethereum Classic (ETC) [Proto Treasury System](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1098.md) (p-ECTS) proposal suggests directing 10% of the miner tax funds to a [Gitcoin grants](https://gitcoin.co/grants/) program. This ECIP proposes to direct those funds to an ETC community managed pool on the [Etherplan Consensus Engine](https://etherplan.com/2021/02/02/the-etherplan-consensus-engine/14989/) (ECE) dapp. The ECE is a system designed for decentralized groups of any kind to distribute funds using rough consensus.
 
 ### Motivation
 
-Currently, the ETC Proto Treasury System (p-ECTS) proposal ECIP-1098 suggests to send 90% of the miner tax to three client members of the treasury, 30% each. The other 10% is suggested to be sent to the Gitcoin grant system. 
+Currently, the ETC Proto Treasury System (p-ECTS) proposal ECIP-1098 suggests to send 90% of the miner tax to three client members of the treasury, 30% each. The other 10% is suggested to be sent to the Gitcoin grant system.
 
 It is the [opinion](https://github.com/input-output-hk/ECIPs/issues/2#issuecomment-702237160) of this author that Gitcoin is not an optimal system to distribute Ethereum Classic treasury funds for projects by individuals, developers, or teams who want to contribute to ETC. Gitcoin is a private Ethereum native project owned, in part, by [ConsenSys](https://media.consensys.net/gitcoin-joins-consensys-announces-pilot-projects-f5a0955de9d6), it uses quadratic funding which exponentiates payments to grantees based on the small contributions of strangers, and constitutes another information hurdle ETC community members would need to overcome to understand who are the grantees, what are their projects, and if they are actually implementing them adequately.
 
@@ -27,20 +27,30 @@ The ECE pool of the ETC ecosystem would have a GitHub repo to edit, control, and
 
 ### Specification
 
-- Replace Gitcoin by directing the suggested 10% p-ECTS miner tax funds to the ETC community's ECE pool contract account in the Ethereum Classic blockchain.
-- Create a repo within the Ethereum Classic GitHub organization for individuals, developers, and teams to enter proposals as pull requests. 
-- This repo may be called the Ethereum Classic Funding Proposal (ECFP) process and it's URL may be `/github.com/ethereumclassic/ECFPs`. 
-- Each funding proposal may be called an ECFP. 
-- Each ECFP must go through a [similar process](https://ecips.ethereumclassic.org/ECIPs/ecip-1000) as ECIPs where proposers, who may be anyone, enter them as pull requests (PRs), so then ECFP administrators (who are analogous to editors in the ECIP process) and proposers may check and correct them, and associate them, if applicable, as competing or complementary to other ECFPs.
-- After ECFP admins and proposers finished setting up ECFP PRs according to the ECFP rules, they may be merged into the repo for community consideration.
-- When ECFPs are merged, they must also be entered into the ECE dapp where all the corresponding smart contracts will be deployed on the layer 2 PoS blockchain (possibly Cardano) and ETC as the base layer, or layer 1.
--  When ECFPs are processed in the ECE dapp, they will either be approved for funding or rejected as per the ECE protocol.
-- Please see the Etherplan Consensus Engine white paper for full details of its operation here: https://etherplan.com/2021/02/02/the-etherplan-consensus-engine/14989/
-- As the Ethereum Classic Proto Treasury System proposal is gaining traction in ETC, and it is proposed by a team from [IOHK](https://github.com/input-output-hk), and IOHK is also the main technical supporter of the [Cardano PoS blockchain](https://iohk.io/en/projects/cardano/), then it makes sense for the PoS execution layer, or layer 2, of the ETC ECE pool to be built on that blockchain.
+-   Replace Gitcoin by directing the suggested 10% p-ECTS miner tax funds to the ETC community's ECE pool contract account in the Ethereum Classic blockchain.
+    
+-   Create a repo within the Ethereum Classic GitHub organization for individuals, developers, and teams to enter proposals as pull requests.
+    
+-   This repo may be called the Ethereum Classic Funding Proposal (ECFP) process and it's URL may be `/github.com/ethereumclassic/ECFPs`.
+    
+-   Each funding proposal may be called an ECFP.
+    
+-   Each ECFP must go through a [similar process](https://ecips.ethereumclassic.org/ECIPs/ecip-1000) as ECIPs where proposers, who may be anyone, enter them as pull requests (PRs), so then ECFP administrators (who are analogous to editors in the ECIP process) and proposers may check and correct them, and associate them, if applicable, as competing or complementary to other ECFPs.
+    
+-   After ECFP admins and proposers finished setting up ECFP PRs according to the ECFP rules, they may be merged into the repo for community consideration.
+    
+-   When ECFPs are merged, they must also be entered into the ECE dapp where all the corresponding smart contracts will be deployed on the layer 2 PoS blockchain (possibly Cardano) and ETC as the base layer, or layer 1.
+    
+-   When ECFPs are processed in the ECE dapp, they will either be approved for funding or rejected as per the ECE protocol.
+    
+-   Please see the Etherplan Consensus Engine white paper for full details of its operation here: [https://etherplan.com/2021/02/02/the-etherplan-consensus-engine/14989/](https://etherplan.com/2021/02/02/the-etherplan-consensus-engine/14989/)
+    
+-   As the Ethereum Classic Proto Treasury System proposal is gaining traction in ETC, and it is proposed by a team from [IOHK](https://github.com/input-output-hk), and IOHK is also the main technical supporter of the [Cardano PoS blockchain](https://iohk.io/en/projects/cardano/), then it makes sense for the PoS execution layer, or layer 2, of the ETC ECE pool to be built on that blockchain.
+    
 
 ### Rationale
 
-The ECE is a consensus engine so it does not distribute funds in a matching format as are typical 1:1 matched grants or CLR matched grants on Gitcoin. However, the Ethereum Classic ecosystem needs a direct way of deciding what projects to fund with its miner tax rather than having third parties from other communities choose their desired projects and then having the p-ECTS matching them. The reason for this is that ETC needs to directly finance to the most relevant projects for its system and promotion, while minimizing the risk of fraud and misdirection of funds to benefit other ecosystems.
+The ECE is a consensus engine so it does not distribute funds in a matching format as are typical 1:1 matched grants or CLR matched grants on Gitcoin. However, the Ethereum Classic ecosystem needs a direct way of deciding what projects to fund with its miner tax rather than having third parties from other communities choose their desired projects and then having the p-ECTS matching them. The reason for this is that ETC needs to directly finance the most relevant projects for its system and promotion, while minimizing the risk of fraud and misdirection of funds to benefit other ecosystems.
 
 The Etherplan Consensus Engine is a native ETC project that is designed to demonstrate the multilayered vision of the blockchain stack, establishing [ETC as the base layer](https://etherplan.com/2019/06/14/bitcoin-and-ethereum-classic-are-complementary-base-layer-systems/7804/) of its system. It also mimics how [rough consensus](https://tools.ietf.org/html/rfc7282) is reached in Bitcoin and Ethereum Classic as a better and more secure way of distribution p-ECTS funds.
 
@@ -48,7 +58,7 @@ The Etherplan Consensus Engine is a native ETC project that is designed to demon
 
 The description of the ECE smart contracts, their functionality, and the general dapp structure are specified in the Etherplan Consensus Engine white paper linked above. The ECE pool for Ethereum Classic to send the 10% of p-ECTS funds could be built with ETC community resources, or other funding sources as this author is not a developer or engineer and does not count with such resources.
 
-The Etherplan Consensus Engine would need intense testing, peer review through this proposal, and smart contracts should be audited thoroughly before sending funds and processing real funding proposals on them. 
+The Etherplan Consensus Engine would need intense testing, peer review through this proposal, and smart contracts should be audited thoroughly before sending funds and processing real funding proposals on them.
 
 Participants, admins, and users will pay the regular layer 1 or layer 2 network gas fees when making proposals, deploying them, or voting on them.
 
@@ -60,7 +70,7 @@ The Etherplan Consensus Engine helps decentralized groups of any kind manage poo
 
 ### Disclaimer
 
-The Etherplan Consensus Engine is an invention by Donald McIntyre, founder of Etherplan. The ETC ECE pool, dapp, and process may serve as a model and test case of the Etherplan Consensus Engine in general. Etherplan may use this model and test case to further develop a dapp for commercial use, similar to how Gitcoin is a commercia dapp, plausibly building an Etherplan Consensus Engine platform for general use by decentralized groups of any kind.
+The Etherplan Consensus Engine is an invention by Donald McIntyre, founder of Etherplan. The ETC ECE pool, dapp, and process may serve as a model and test case of the Etherplan Consensus Engine in general. Etherplan may use this model and test case to further develop a dapp for commercial use, similar to how Gitcoin is a commercial dapp, plausibly building an Etherplan Consensus Engine platform for general use by decentralized groups of any kind.
 
 The above means that, indeed, the ECE is a bona fide proposal as the best decision making process for the ETC community to distribute treasury funds, but it will also benefit Etherplan for private business purposes in case it launches the ECE model as a general use commercial dapp. Consequently, any potential support or investment of ETC community resources in building the first ECE pool may directly or indirectly benefit Etherplan.
 
@@ -68,4 +78,6 @@ However, The Etherplan Consensus Engine is licensed as an open source project un
 
 ### Copyright/Licensing
 
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>..
+![Creative Commons License](https://lh6.googleusercontent.com/_3dmztpIPk1jXnWGO1l8Wl3Li3D9ctONrBnghPm9lOUshiwyfabzwQJDLDdYlyYjcdMUOr2A6_YsVEUNzY9ggYuXQDlRxr4RIdtqrdugTOd5P6PfuaaHrHH318S5M2pgrFTKXdpg)
+
+This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/_specs/ecip-1102.md
+++ b/_specs/ecip-1102.md
@@ -50,7 +50,7 @@ The description of the ECE smart contracts, their functionality, and the general
 
 The Etherplan Consensus Engine would need intense testing, peer review through this proposal, and smart contracts should be audited thoroughly before sending funds and processing real funding proposals on them. 
 
-Participants, admins, and users will pay the regular layer 1 or layer 2 network gas fees whe making proposalas, deploying them or voting on them.
+Participants, admins, and users will pay the regular layer 1 or layer 2 network gas fees when making proposals, deploying them, or voting on them.
 
 Building the ECE for this proposal as a community effort and investment could potentially benefit Etherplan privately as explained in the disclaimer section below.
 

--- a/_specs/ecip-1102.md
+++ b/_specs/ecip-1102.md
@@ -48,9 +48,11 @@ The Etherplan Consensus Engine is a native ETC project that is designed to demon
 
 The description of the ECE smart contracts, their functionality, and the general dapp structure are specified in the Etherplan Consensus Engine white paper linked above. The ECE pool for Ethereum Classic to send the 10% of p-ECTS funds could be built with ETC community resources, or other funding sources as this author is not a developer or engineer and does not count with such resources.
 
-The Etherplan Consensus Engine would need intense testing, peer review through this proposal, and smart contracts should be audited thoroughly before sending funds and processing real funding proposals on them.
+The Etherplan Consensus Engine would need intense testing, peer review through this proposal, and smart contracts should be audited thoroughly before sending funds and processing real funding proposals on them. 
 
-Building the ECE for this proposal as a community effort and investment could potentially benefit Etherplan privately as explained in the disclaimer section below. However, except for regular layer 1 or layer 2 network gas fees, no fees or any revenues to Etherplan will ever be charged from the ETC ECE pool mentioned in this document. 
+Participants, admins, and users will pay the regular layer 1 or layer 2 network gas fees whe making proposalas, deploying them or voting on them.
+
+Building the ECE for this proposal as a community effort and investment could potentially benefit Etherplan privately as explained in the disclaimer section below.
 
 ### About The Etherplan Consensus Engine
 

--- a/_specs/ecip-1102.md
+++ b/_specs/ecip-1102.md
@@ -1,0 +1,71 @@
+---
+ecip: 1102
+title: Use The Etherplan Consensus Engine for Approving Proto Treasury Funding Proposals
+lang: EN
+author: Donald McIntyre (@TokenHash)
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/407
+status: WIP
+type: Meta
+created: 2021-02-03
+complementary to: ECIP-1098 Proto Treasury System 
+license: Apache-2
+---
+
+### Abstract
+
+The Ethereum Classic (ETC) [Proto Treasury System](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1098.md) (p-ECTS) proposal suggests to direct 10% of the miner tax funds to a [Gitcoin grants](https://gitcoin.co/grants/) program. This ECIP proposes to direct those fund to an ETC community managed pool on the [Etherplan Consensus Engine](https://etherplan.com/2021/02/02/the-etherplan-consensus-engine/14989/) (ECE) dapp. The ECE is a system designed for decentralized groups of any kind to distribute funds using rough consensus.
+
+### Motivation
+
+Currently, the ETC Proto Treasury System (p-ECTS) proposal ECIP-1098 suggests to send 90% of the miner tax to three client members of the treasury, 30% each. The other 10% is suggested to be sent to the Gitcoin grant system. 
+
+It is the [opinion](https://github.com/input-output-hk/ECIPs/issues/2#issuecomment-702237160) of this author that Gitcoin is not an optimal system to distribute Ethereum Classic treasury funds for projects by individuals, developers, or teams who want to contribute to ETC. Gitcoin is a private Ethereum native project owned, in part, by [ConsenSys](https://media.consensys.net/gitcoin-joins-consensys-announces-pilot-projects-f5a0955de9d6), it uses quadratic funding which exponentiates payments to grantees based on the small contributions of strangers, and constitutes another information hurdle ETC community members would need to overcome to understand who are the grantees, what are their projects, and if they are actually implementing them adequately.
+
+The Etherplan Consensus Engine, a private Ethereum Classic native project owned by Donald McIntyre, founder of [Etherplan](https://etherplan.com/about/), is proposed as the replacement of Gitcoin in the p-ECTS so ETC community members may have a direct say in what projects are funded on a rough consensus basis, which is ETC's historical method of making decisions, rather than on the contributions of third parties.
+
+The ECE pool of the ETC ecosystem would have a GitHub repo to edit, control, and associate funding proposals with a similar, but not identical, process as the Ethereum Classic Improvement Proposal (ECIP) process.
+
+### Specification
+
+- Replace Gitcoin by directing the suggested 10% p-ECTS miner tax funds to the ETC community's ECE pool contract account in the Ethereum Classic blockchain.
+- Create a repo within the Ethereum Classic GitHub organization for individuals, developers, and teams to enter proposals as pull requests. 
+- This repo may be called the Ethereum Classic Funding Proposal (ECFP) process and it's URL may be `/github.com/ethereumclassic/ECFPs`. 
+- Each funding proposal may be called an ECFP. 
+- Each ECFP must go through a [similar process](https://ecips.ethereumclassic.org/ECIPs/ecip-1000) as ECIPs where proposers, who may be anyone, enter them as pull requests (PRs), so then ECFP administrators (who are analogous to editors in the ECIP process) and proposers may check and correct them, and associate them, if applicable, as competing or complementary to other ECFPs.
+- After ECFP admins and proposers finished setting up ECFP PRs according to the ECFP rules, they may be merged into the repo for community consideration.
+- When ECFPs are merged, they must also be entered into the ECE dapp where all the corresponding smart contracts will be deployed on the layer 2 PoS blockchain (possibly Cardano) and ETC as the base layer, or layer 1.
+-  When ECFPs are processed in the ECE dapp, they will either be approved for funding or rejected as per the ECE protocol.
+- Please see the Etherplan Consensus Engine white paper for full details of its operation here: https://etherplan.com/2021/02/02/the-etherplan-consensus-engine/14989/
+- As the Ethereum Classic Proto Treasury System proposal is gaining traction in ETC, and it is proposed by a team from [IOHK](https://github.com/input-output-hk), and IOHK is also the main technical supporter of the [Cardano PoS blockchain](https://iohk.io/en/projects/cardano/), then it makes sense for the PoS execution layer, or layer 2, of the ETC ECE pool to be built on that blockchain.
+
+### Rationale
+
+The ECE is a consensus engine so it does not distribute funds in a matching format as are typical 1:1 matched grants or CLR matched grants on Gitcoin. However, the Ethereum Classic ecosystem needs a direct way of deciding what projects to fund with its miner tax rather than having third parties from other communities choose their desired projects and then having the p-ECTS matching them. The reason for this is that ETC needs to directly finance to the most relevant projects for its system and promotion, while minimizing the risk of fraud and misdirection of funds to benefit other ecosystems.
+
+The Etherplan Consensus Engine is a native ETC project that is designed to demonstrate the multilayered vision of the blockchain stack, establishing [ETC as the base layer](https://etherplan.com/2019/06/14/bitcoin-and-ethereum-classic-are-complementary-base-layer-systems/7804/) of its system. It also mimics how [rough consensus](https://tools.ietf.org/html/rfc7282) is reached in Bitcoin and Ethereum Classic as a better and more secure way of distribution p-ECTS funds.
+
+### Implementation
+
+The description of the ECE smart contracts, their functionality, and the general dapp structure are specified in the Etherplan Consensus Engine white paper linked above. The ECE pool for Ethereum Classic to send the 10% of p-ECTS funds could be built with ETC community resources, or other funding sources as this author is not a developer or engineer and does not count with such resources.
+
+The Etherplan Consensus Engine would need intense testing, peer review through this proposal, and smart contracts should be audited thoroughly before sending funds and processing real funding proposals on them.
+
+Building the ECE for this proposal as a community effort and investment could potentially benefit Etherplan privately as explained in the disclaimer section below. However, except for regular layer 1 or layer 2 network gas fees, no fees or any revenues to Etherplan will ever be charged from the ETC ECE pool mentioned in this document. 
+
+### About The Etherplan Consensus Engine
+
+The Etherplan Consensus Engine helps decentralized groups of any kind manage pools of money on blockchains using rough consensus in a secure, objective, transparent, and mechanical way. The system mimics neural computations where the internal computations of smart contracts, coupled with the interactions between contracts, have the overall effect of reducing noise and increasing relevance for sound decision making. Participants, administrators, and proposers are connected with the pools of capital they manage or solicit funds from in a three layered modular system that optimizes the distribution of risk and computational load in a highly cost effective way. It achieves this by leveraging a web interface for a better user experience; a proof of stake blockchain as an execution layer (Cardano), or layer 2, for performance; and a proof of work blockchain as a base layer (Ethereum Classic), or layer 1, for security, custody, settlements, and auditable record keeping.
+
+### Disclaimer
+
+The Etherplan Consensus Engine is a commercial invention by Donald McIntyre, founder of Etherplan. The ECE dapp for the ETC community will be licensed for free, for exclusive use, for its intended purposes of benefiting the Ethereum Classic blockchain, for the ETC community and ecosystem. Etherplan will not charge any commissions or fees for its use by the Ethereum Classic blockchain ecosystem in perpetuity if they implement it. 
+
+However, the ETC ECE pool, dapp, and process may serve as a model and test case of the Etherplan Consensus Engine in general. Etherplan may use this model and test case to further develop a dapp for commercial use, plausibly building an Etherplan Consensus Engine platform for general use by decentralized groups of any kind.
+
+The above means that, indeed, the ECE is a bona fide proposal as the best decision making process for the ETC community to distribute treasury funds, but it will also benefit Etherplan for private business purposes in case it launches the ECE model as a general use commercial dapp. Consequently, any potential support or investment of ETC community resources in building the first ECE pool may directly benefit Etherplan.  
+
+### Copyright/Licensing
+
+The Etherplan Consensus Engine is an invention and intellectual property of Donald McIntyre, founder of Etherplan.
+
+This particular ECIP-1102 is licensed under Apache-2.

--- a/_specs/ecip-1102.md
+++ b/_specs/ecip-1102.md
@@ -8,7 +8,7 @@ status: WIP
 type: Meta
 created: 2021-02-03
 complementary to: ECIP-1098 Proto Treasury System 
-license: Apache-2
+license: CC-BY-SA
 ---
 
 ### Abstract
@@ -21,7 +21,7 @@ Currently, the ETC Proto Treasury System (p-ECTS) proposal ECIP-1098 suggests to
 
 It is the [opinion](https://github.com/input-output-hk/ECIPs/issues/2#issuecomment-702237160) of this author that Gitcoin is not an optimal system to distribute Ethereum Classic treasury funds for projects by individuals, developers, or teams who want to contribute to ETC. Gitcoin is a private Ethereum native project owned, in part, by [ConsenSys](https://media.consensys.net/gitcoin-joins-consensys-announces-pilot-projects-f5a0955de9d6), it uses quadratic funding which exponentiates payments to grantees based on the small contributions of strangers, and constitutes another information hurdle ETC community members would need to overcome to understand who are the grantees, what are their projects, and if they are actually implementing them adequately.
 
-The Etherplan Consensus Engine, a private Ethereum Classic native project owned by Donald McIntyre, founder of [Etherplan](https://etherplan.com/about/), is proposed as the replacement of Gitcoin in the p-ECTS so ETC community members may have a direct say in what projects are funded on a rough consensus basis, which is ETC's historical method of making decisions, rather than on the contributions of third parties.
+The Etherplan Consensus Engine, an Ethereum Classic native project by Donald McIntyre, founder of [Etherplan](https://etherplan.com/about/), is proposed as the replacement of Gitcoin in the p-ECTS so ETC community members may have a direct say in what projects are funded on a rough consensus basis, which is ETC's historical method of making decisions, rather than on the contributions of third parties.
 
 The ECE pool of the ETC ecosystem would have a GitHub repo to edit, control, and associate funding proposals with a similar, but not identical, process as the Ethereum Classic Improvement Proposal (ECIP) process.
 
@@ -58,14 +58,12 @@ The Etherplan Consensus Engine helps decentralized groups of any kind manage poo
 
 ### Disclaimer
 
-The Etherplan Consensus Engine is a commercial invention by Donald McIntyre, founder of Etherplan. The ECE dapp for the ETC community will be licensed for free, for exclusive use, for its intended purposes of benefiting the Ethereum Classic blockchain, for the ETC community and ecosystem. Etherplan will not charge any commissions or fees for its use by the Ethereum Classic blockchain ecosystem in perpetuity if they implement it. 
+The Etherplan Consensus Engine is an invention by Donald McIntyre, founder of Etherplan. The ETC ECE pool, dapp, and process may serve as a model and test case of the Etherplan Consensus Engine in general. Etherplan may use this model and test case to further develop a dapp for commercial use, similar to how Gitcoin is a commercia dapp, plausibly building an Etherplan Consensus Engine platform for general use by decentralized groups of any kind.
 
-However, the ETC ECE pool, dapp, and process may serve as a model and test case of the Etherplan Consensus Engine in general. Etherplan may use this model and test case to further develop a dapp for commercial use, plausibly building an Etherplan Consensus Engine platform for general use by decentralized groups of any kind.
+The above means that, indeed, the ECE is a bona fide proposal as the best decision making process for the ETC community to distribute treasury funds, but it will also benefit Etherplan for private business purposes in case it launches the ECE model as a general use commercial dapp. Consequently, any potential support or investment of ETC community resources in building the first ECE pool may directly or indirectly benefit Etherplan.
 
-The above means that, indeed, the ECE is a bona fide proposal as the best decision making process for the ETC community to distribute treasury funds, but it will also benefit Etherplan for private business purposes in case it launches the ECE model as a general use commercial dapp. Consequently, any potential support or investment of ETC community resources in building the first ECE pool may directly benefit Etherplan.  
+However, The Etherplan Consensus Engine is licensed as an open source project under CC-BY-SA as seen below.
 
 ### Copyright/Licensing
 
-The Etherplan Consensus Engine is an invention and intellectual property of Donald McIntyre, founder of Etherplan.
-
-This particular ECIP-1102 is licensed under Apache-2.
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>..


### PR DESCRIPTION
Proposing The Etherplan Consensus Engine so the ETC community may use it to distribute proto treasury funds to projects that benefit ETC.