### PR TITLE
ecip-1103: bump status to accepted

### DIFF
--- a/_specs/ecip-1103.md
+++ b/_specs/ecip-1103.md
@@ -3,7 +3,6 @@ lang: en
 ecip: 1103
 title: Magneto EVM and Protocol Upgrades
 status: Accepted
-review-period-end: 2021-06-04
 type: Meta
 author: Afr Schoe (@q9f)
 created: 2021-02-09

--- a/_specs/ecip-1103.md
+++ b/_specs/ecip-1103.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1103
 title: Magneto EVM and Protocol Upgrades
-status: Last Call
+status: Accepted
 review-period-end: 2021-06-04
 type: Meta
 author: Afr Schoe (@q9f)


### PR DESCRIPTION
Per https://github.com/ethereumclassic/ECIPs/pull/425#issue-637825787, waiting period for _Last Call_ ends June 4th, today.
I am not aware of any last minute concerns or showstoppers raised.

