### PR TITLE
Withdraw ECIP-1097/98

### DIFF
--- a/_specs/ecip-1097.md
+++ b/_specs/ecip-1097.md
@@ -4,7 +4,7 @@ title: Checkpointing based 51% attack resistance
 lang: en
 author: Dimitris Karakostas (@dimkarakostas), Radek Tkaczyk (@rtkaczyk), Romain Pellerin (@romainPellerin), Brian McKenna (@bpmckenna)
 discussions-to: https://github.com/input-output-hk/ECIPs/issues/1
-status: Draft
+status: Withdrawn
 type: Standards Track
 category: Core
 created: 2020-08-26

--- a/_specs/ecip-1098.md
+++ b/_specs/ecip-1098.md
@@ -4,7 +4,7 @@ title: Proto Treasury System
 lang: en
 author: Julian Mendiola (@jmendiola222), Nicolas Tallar(@ntallar), Brian McKenna(@bpmckenna)
 discussions-to: https://github.com/input-output-hk/ECIPs/issues/2
-status: Draft
+status: Withdrawn
 type: Standards Track
 category: Core
 created: 2020-08-26


### PR DESCRIPTION
Mantis Team will be withdrawing ECIP-1097/98. For further context see our [announcement ](https://discord.com/channels/776738722733490196/776738722733490199/897045745742524436).