### PR TITLE
Withdraw ECIP-1084 "Hard-cap gas-limit in protocol".

### DIFF
--- a/_specs/ecip-1084.md
+++ b/_specs/ecip-1084.md
@@ -3,7 +3,7 @@ lang: en
 ecip: 1084
 title: Hard-cap gas-limit in protocol
 author: Bob Summerwill (@bobsummerwill)
-status: Draft
+status: Withdrawn
 type: Standards Track
 category: Core
 created: 2020-01-17


### PR DESCRIPTION
There was no consensus around this change, which is nearly two years old now.