### PR TITLE
[ECIP-1104] BASEFEE omit, activations, last call

### DIFF
--- a/_specs/ecip-1104.md
+++ b/_specs/ecip-1104.md
@@ -35,7 +35,7 @@ The fee market change and bomb delay are omitted at this time as they are not ap
 #### EIP Summaries and expected action
 ##### Included
 - EIP 3198 "BASEFEE opcode": Adds an opcode that gives the EVM access to the block’s base fee. 
-  - For ETC, BASEFEE opcode shall return `0`. This opcode is being added to ensure alignement with evm standards but will not be used on chain. The assumption being that contracts using `BASEFEE` sould do `GASPRICE - BASEFEE` to get the proper value   
+  - For ETC, BASEFEE opcode shall return `0`. This opcode is being added to ensure alignment with evm standards but will not be used on chain. The assumption being that contracts using `BASEFEE` sould do `GASPRICE - BASEFEE` to get the proper value   
 - EIP 3529 "Alternative refund reduction" Remove gas refunds for SELFDESTRUCT, and reduce gas refunds for SSTORE to a lower level where the refunds are still substantial, but they are no longer high enough for current “exploits” of the refund mechanism to be viable.
   - gas price should be adjusted on respective opcodes to reflect the new EVM standard   
 - EIP 3541 "Reject new contracts starting with the 0xEF byte": Disallow new code starting with the 0xEF byte to be deployed. Code already existing in the account trie starting with 0xEF byte is not affected semantically by this change.

--- a/_specs/ecip-1104.md
+++ b/_specs/ecip-1104.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1104
 title:  Mystique EVM and Protocol Upgrades
-status: Last call
+status: Last Call
 type: Meta
 author: Cody Burns (@dontpanicburns)
 created: 2021-07-28

--- a/_specs/ecip-1104.md
+++ b/_specs/ecip-1104.md
@@ -43,7 +43,7 @@ The fee market change and bomb delay are omitted at this time as they are not ap
 - EIP 1559 "Fee market change": A transaction pricing mechanism that includes fixed-per-block network fee that is burned and dynamically expands/contracts block sizes to deal with transient congestion.
   - Undesirable to implement at this time as it would conflict with the current monetary policy set in ECIP-1017  
 - EIP 3198 "BASEFEE opcode": Adds an opcode that gives the EVM access to the block’s base fee. 
-  - It depends on EIP-1559 and it wouldn't make sense in the context of ETC
+  - It depends on EIP-1559. Behavior specifications for use in context without EIP-1559 are undefined.
 - EIP 3228 "💣 delay": Delays the difficulty bomb to show effect the first week of December 2021.
   - Not applicable to ETC due to difficulty bomb being defused 
 

--- a/_specs/ecip-1104.md
+++ b/_specs/ecip-1104.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1104
 title:  Mystique EVM and Protocol Upgrades
-status: Draft
+status: Last call
 type: Meta
 author: Cody Burns (@dontpanicburns)
 created: 2021-07-28

--- a/_specs/ecip-1104.md
+++ b/_specs/ecip-1104.md
@@ -51,9 +51,9 @@ The fee market change and bomb delay are omitted at this time as they are not ap
 This document proposes the following blocks at which to implement these changes
 in the Classic networks:
 
-- `Dec 15th 2022` on Mordor Classic PoW-testnet 
-- `Jan 5th 2022` on Kotti Classic PoA-testnet 
-- `Jan 19th 2022` on Ethereum Classic PoW-mainnet 
+- `5_414_000` on Mordor Classic PoW-testnet (Jan 10th 2022)
+- `5_559_000` on Kotti Classic PoA-testnet (Jan 20th 2022)
+- `14_502_000` on Ethereum Classic PoW-mainnet (Feb 10th 2022)
 
 For more information on the opcodes and their respective EIPs and
 implementations, please see the _Specification_ section of this document.

--- a/_specs/ecip-1104.md
+++ b/_specs/ecip-1104.md
@@ -23,10 +23,10 @@ changes for Ethereum Classic's _London_ upgrade include:
 
 EIP | Eth PR | omit or include
 -- | -- | --
-3198 (BASEFEE opcode) | #22837 | Include
 3529 (Alternative refund reduction) | #22733 | Include
 3541 (Reject new contracts starting with the 0xEF byte) | #22809 | Include
 1559 (Fee market change) | #22837 #22896 |  Omit
+3198 (BASEFEE opcode) | #22837 | Omit
 3228 (💣 delay) | #22840 and #22870 | Omit
 
 The fee market change and bomb delay are omitted at this time as they are not applicable for Ethereum Classic. The fee market change puts the network at longterm risk since as ETC currently has a capped supply and fixed emmision epocs. The bomb was disarmed in ETC code base in a previous hardfork. 
@@ -34,8 +34,6 @@ The fee market change and bomb delay are omitted at this time as they are not ap
 
 #### EIP Summaries and expected action
 ##### Included
-- EIP 3198 "BASEFEE opcode": Adds an opcode that gives the EVM access to the block’s base fee. 
-  - For ETC, BASEFEE opcode shall return `0`. This opcode is being added to ensure alignment with evm standards but will not be used on chain. The assumption being that contracts using `BASEFEE` sould do `GASPRICE - BASEFEE` to get the proper value   
 - EIP 3529 "Alternative refund reduction" Remove gas refunds for SELFDESTRUCT, and reduce gas refunds for SSTORE to a lower level where the refunds are still substantial, but they are no longer high enough for current “exploits” of the refund mechanism to be viable.
   - gas price should be adjusted on respective opcodes to reflect the new EVM standard   
 - EIP 3541 "Reject new contracts starting with the 0xEF byte": Disallow new code starting with the 0xEF byte to be deployed. Code already existing in the account trie starting with 0xEF byte is not affected semantically by this change.
@@ -44,6 +42,8 @@ The fee market change and bomb delay are omitted at this time as they are not ap
 ##### Omitted
 - EIP 1559 "Fee market change": A transaction pricing mechanism that includes fixed-per-block network fee that is burned and dynamically expands/contracts block sizes to deal with transient congestion.
   - Undesirable to implement at this time as it would conflict with the current monetary policy set in ECIP-1017  
+- EIP 3198 "BASEFEE opcode": Adds an opcode that gives the EVM access to the block’s base fee. 
+  - It depends on EIP-1559 and it wouldn't make sense in the context of ETC
 - EIP 3228 "💣 delay": Delays the difficulty bomb to show effect the first week of December 2021.
   - Not applicable to ETC due to difficulty bomb being defused 
 

--- a/_specs/ecip-1104.md
+++ b/_specs/ecip-1104.md
@@ -107,16 +107,6 @@ features currently and will be able to support the _Mystique_ upgrade:
 - Core-Geth (maintained by ETC Core)
 - Hyperledger Besu (maintained by ConsenSys)
 
-### Proposed Timeline
-
-- make sure draft will be ready and "pre-approved" by the core teams
-have some rough consensus to put it in last call ("day X")
-- Nov 23 + 2 weeks - move to accepted unless there are issues/concerns
-- Dec 15th - Mordor activation
-- Jan 5th - Kotti activation
-- Jan 26th - Mainnet activation
-
-
 ## Copyright
 
 Copyright and related rights waived via


### PR DESCRIPTION
This PR proposes the following changes:
  - Exclude EIP-3198: `BASEFEE` Opcode from Mystique 
  - Add block number activation for each network based on the following calculations
    * **Mordor** (1587460 seconds until Jan 10th 2022): `5_294_406 block + 1_587_460 secs / 13.3 secs/block ~= 5_414_000 block`
    *  **Kotti** (2449694 seconds until Jan 20th 2022): `5_395_501 block + 2_449_694 secs / 15 secs/block ~= 5_559_000 block`
    *  **Mainnet** (4264005 seconds until Feb 10th 2022): `14_181_120 block + 4_264_005 secs / 13.3 secs/block ~= 14_502_000 block`
  - Change ECIP status to _Last call_

Ref: discussion #440 