### PR TITLE
[1104] Increase Mystique activation block numbers in all networks

### DIFF
--- a/_specs/ecip-1104.md
+++ b/_specs/ecip-1104.md
@@ -51,9 +51,9 @@ The fee market change and bomb delay are omitted at this time as they are not ap
 This document proposes the following blocks at which to implement these changes
 in the Classic networks:
 
-- `5_414_000` on Mordor Classic PoW-testnet (Jan 10th 2022)
-- `5_559_000` on Kotti Classic PoA-testnet (Jan 20th 2022)
-- `14_502_000` on Ethereum Classic PoW-mainnet (Feb 10th 2022)
+- `5_520_000` on Mordor Classic PoW-testnet (Jan 13th 2022)
+- `5_578_000` on Kotti Classic PoA-testnet (Jan 23th 2022)
+- `14_525_000` on Ethereum Classic PoW-mainnet (Feb 13th 2022)
 
 For more information on the opcodes and their respective EIPs and
 implementations, please see the _Specification_ section of this document.


### PR DESCRIPTION
This PR proposes the following changes:
  - Given that the proposed Mordor block for activating Mystique already passed, and to give the community enough time to update their clients, the following new block numbers are proposed
    * **Mordor** (488723 seconds until Jan 13th 2022): `5_479_462 block + 487_261 secs / 12 secs/block ~= 5_520_000 block`
    * **Kotti** (1352603 seconds until Jan 23rd 2022): `5_487_158 block + 1_351_173 secs / 15 secs/block ~= 5_578_000 block`
    * **Mainnet** (3166978 seconds until Feb 13th 2022): `14_285_039 block + 3_165_459 secs / 13.2 secs/block ~= 14_525_000 block`

Ref: discussion #440 