### PR TITLE
Editorial: Fix/ecip 1049

### DIFF
--- a/_specs/ecip-1049.md
+++ b/_specs/ecip-1049.md
@@ -42,6 +42,10 @@ In Solidity, developers have access to the `keccak256()` function, which allows 
 
 With the direction that Ethereum Classic is taking: a focus on Layer-2 solutions and cross-chain compatibility; being able to evaluate proof of work on chain, will be tremendously valuable to developers of both smart-contracts and node software writers. This could greatly simplify interoperability. 
 
+### Specification
+
+Use Keccak256 with no DAG instead of ~~Ethash~~ Etchash as the proof-of-work mechanism on Ethereum Classic.
+
 ### Implementation
 
 Work in Progress:

--- a/_specs/ecip-1049.md
+++ b/_specs/ecip-1049.md
@@ -8,6 +8,7 @@ category: Core
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/394
 author: Bob Summerwill <bob@etccooperative.org>, Alexander Tsankov <alexander.tsankov@colorado.edu>
 created: 2019-01-08
+license: Apache-2.0
 ---
 
 ### Abstract


### PR DESCRIPTION
- [x] add missing `License` field in header
- [x] add missing `Specification` section

Per the bureaucratic regulations at [`ECIP Format and Structure`](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1000.md#ecip-format-and-structure).