### PR TITLE
Rename: Alphabetize Editors List, Add Current Team Association to Current Editors

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -72,20 +72,20 @@ A good reason to transfer ownership is because the original author no longer has
 
 Current ECIP editors:
 
-* Antoine Toulme (@atoulme)
-* gitr0n1n (@gitr0n1n)
-* Istora Mandiri (@IstoraMandiri)
-* Mr. Meows D. Bits (@meowsbits)
-* Talha Cross (@soc1c)
+* Antoine Toulme (@atoulme) - ETC Coop
+* gitr0n1n (@gitr0n1n) - Independent
+* Istora Mandiri (@IstoraMandiri) - Independent
+* Mr. Meows D. Bits (@meowsbits) - ETC Coop
 
 Former ECIP editors:
 
-* Wei Tang (@sorpaas)
-* Yaz Khoury (@YazzyYaz)
-* Cody Burns (@realcodywburns)
-* Stevan Lohja (@stevanlohja)
 * Zachary Belford (@BelfordZ)
 * Felipe Faraggi (@faraggi)
+* Cody Burns (@realcodywburns)
+* Talha Cross (@soc1c)
+* Wei Tang (@sorpaas)
+* Stevan Lohja (@stevanlohja)
+* Yaz Khoury (@YazzyYaz)
 
 ## ECIP Editor Responsibilities & Workflow
 

--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -72,7 +72,6 @@ A good reason to transfer ownership is because the original author no longer has
 
 Current ECIP editors:
 
-* Antoine Toulme (@atoulme) - ETC Coop
 * gitr0n1n (@gitr0n1n) - Independent
 * Istora Mandiri (@IstoraMandiri) - Independent
 * Mr. Meows D. Bits (@meowsbits) - ETC Coop


### PR DESCRIPTION
- ~~move soc1c to former editor list~~ (addressed in PR 468 per requested change)
- update current editors list to github perms.
- add teams of current editors for transparency. proper checks and balances.
- alphabetize Editor lists via handle

Addresses PR:
* https://github.com/ethereumclassic/ECIPs/pull/468