### PR TITLE
Adjust withdrawn ECIP-0001 to ECIP-1107 for editor/public clarity

### DIFF
--- a/_specs/ECIP-1107.md
+++ b/_specs/ECIP-1107.md
@@ -1,6 +1,6 @@
 ---
 lang: en
-ecip: 0001
+ecip: 1107
 title: ECIP Process
 status: Withdrawn
 type: Meta
@@ -177,7 +177,7 @@ There are three types of ECIP:
   - **Networking** - improvements to networking protocol specifications.
   - **Interface** - improvements around client [API/RPC] specifications and standards, and also certain language-level standards like method names  and contract ABIs.
   - **ECBP (Ethereum Classic Best Practice)** - application-level standards and conventions, including contract standards such as token standards, name registries, URI schemes, library/package formats, and wallet formats.
-- A **Meta ECIP** describes a **process** surrounding Ethereum Classic or proposes a change to (or an event in) a process. Process ECIPs are like Standard Track ECIPs, but apply to areas other than the Ethereum Classic protocol itself. They may propose an implementation, but not to Ethereum Classic's codebase; they often require community consensus; unlike Informational ECIPs, they are more than recommendations, and users are typically not free to ignore them. Examples include procedures, guidelines, changes to the decision-making process (e.g. this ECIP-0001 process document), and changes to the tools or environment used in Ethereum Classic development. *Any meta-ECIP is also considered a Process ECIP.*
+- A **Meta ECIP** describes a **process** surrounding Ethereum Classic or proposes a change to (or an event in) a process. Process ECIPs are like Standard Track ECIPs, but apply to areas other than the Ethereum Classic protocol itself. They may propose an implementation, but not to Ethereum Classic's codebase; they often require community consensus; unlike Informational ECIPs, they are more than recommendations, and users are typically not free to ignore them. Examples include procedures, guidelines, changes to the decision-making process (e.g. this ECIP-1107 process document), and changes to the tools or environment used in Ethereum Classic development. *Any meta-ECIP is also considered a Process ECIP.*
 - An **Informational ECIP** describes an Ethereum Classic design issue, or provides general guidelines or information to the Ethereum Classic community, but does not propose a new feature. Informational ECIPs do not necessarily represent Ethereum Classic community consensus or a recommendation, so users and implementors are free to ignore Informational ECIPs or follow their advice.
 
 It is highly recommended that a single ECIP contain a single key proposal or new idea. The more focused the ECIP, the more successful it tends to be. A change to one client doesn't require an ECIP; a change that affects multiple clients, or defines a standard for multiple apps to use, does.
@@ -265,11 +265,11 @@ If an ECIP is not yet completed, reviewers should instead post on the applicable
 
 Some ECIPs receive exposure outside the development community prior to completion, and other ECIPs might not be completed at all. To avoid a situation where critical ECIP reviews may go unnoticed during this period, reviewers may, at their option, still post their review on the comments page, provided they first post it to the mailing list and plan to later remove or revise it as applicable based on the completed version. Such revisions should be made by editing the previous review and updating the timestamp. Reviews made prior to the complete version may be removed if they are no longer applicable and have not been updated in a timely manner (eg, within one month).
 
-Pages must be named after the full ECIP number (eg, "ECIP 0001") and placed in the "Comments" namespace.
+Pages must be named after the full ECIP number (eg, "ECIP 1107") and placed in the "Comments" namespace.
 
 For example, the link for ECIP 1 will be:
 
-	https://github.com/ethereumclassic/ECIPs/wiki/Comments:ECIP-0001 .
+	https://github.com/ethereumclassic/ECIPs/wiki/Comments:ECIP-1107 .
 
 Comments posted to this wiki should use the following format:
 
@@ -380,7 +380,7 @@ In addition, it is recommended that literal code included in the ECIP be dual-li
 
 3. Participant privacy will be respected. Publishing other participant’s private information, such as a physical or email addresses, or real names, without their explicit permission is not allowed within the ECIP process nor in other public forums.
 
-4. Ethereum Classic organization owners on Github or other platforms in use, ECIP repo admins, and ECIP editors have the right and responsibility to remove ECIP participants of any kind, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this ECIP-0001 and Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+4. Ethereum Classic organization owners on Github or other platforms in use, ECIP repo admins, and ECIP editors have the right and responsibility to remove ECIP participants of any kind, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this ECIP-1107 and Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Rationale
 


### PR DESCRIPTION
This is a withdrawn ECIP that ECIP editors occasionally confuse with the active ECIP-1000 due to its numbering. Move to 1107 to correct this mistake given ECIP-1000's importance to the ECIP process. Save editors from having to redraft to the correct ECIP-1000 file.

recent example of this common editing error: https://github.com/ethereumclassic/ECIPs/pull/468
suggested fix: https://github.com/ethereumclassic/ECIPs/pull/468#pullrequestreview-893957293