### PR TITLE
Withdraw ECIP-1049: "Change the ETC Proof of Work Algorithm to Keccak256"

### DIFF
--- a/_specs/ecip-1049.md
+++ b/_specs/ecip-1049.md
@@ -1,8 +1,8 @@
 ---
 lang: en
 ecip: 1049
-title: [WIP] Change the ETC Proof of Work Algorithm to Keccak256
-status: Draft
+title: Change the ETC Proof of Work Algorithm to Keccak256
+status: Withdrawn
 type: Standards Track
 category: Core
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/394
@@ -10,12 +10,6 @@ author: Bob Summerwill <bob@etccooperative.org>, Alexander Tsankov <alexander.ts
 created: 2019-01-08
 license: Apache-2.0
 ---
-
-### Work in Progress
-
-	Work in progress (WIP) -- An ECIP where the author has asked the Ethereum Classic community whether an idea has any chance of support, he/she will write a draft ECIP as a pull request. However, if the idea is still in a very early stage, and will have a lot of commits and changes by the author, editors or contributors, it may be better to enter it as a WIP. Make sure to add [WIP] in the title (example: [WIP] ECIP-X) of the early stage ECIP so other members can mute it if they are not interested in participating at this stage.
-
-Read more about Ethereum Classic Improvement Proposals (ECIPs) at [https://github.com/ethereumclassic/ECIPs](https://github.com/ethereumclassic/ECIPs) and [ECIP-1000](http://ecips.ethereumclassic.org/ECIPs/ecip-1000).
 
 ### Abstract
 


### PR DESCRIPTION
There has not been any active work on this for several months.
There is not clear consensus on activation of the feature.
We have also missed the boat to make a transition prior to Ethereum's "The Merge" event, and the anticipated flood of hashrate into ETC.
