### PR TITLE
peg docker jekyll/builder at v3 tag

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -14,4 +14,4 @@ jobs:
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+        jekyll/builder:3 /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"


### PR DESCRIPTION
Builds with docker's `jekyll/builder:latest` are failing because dependency hell.

See failing build at one of the latest PRs: https://github.com/ethereumclassic/ECIPs/runs/7325591137?check_suite_focus=true (https://github.com/ethereumclassic/ECIPs/pull/489)

Proof that this actually fixes it:
- https://github.com/meowsbits/ECIPs/tree/fix/jekyll
- https://github.com/meowsbits/ECIPs/actions/runs/2678686409
