### PR TITLE
Updates to the "Ethereum Classic Network Description" which is the canonical description of ETC hard forks

### DIFF
--- a/_specs/ecip-1066.md
+++ b/_specs/ecip-1066.md
@@ -15,10 +15,11 @@ Ethereum Classic network mainnet.
 | ---------- | ------------ | ---------------------- | -------------------------------------------------------------- |
 | 2015-07-30 |            0 | Frontier               | [EIP-684](https://github.com/ethereum/EIPs/issues/684)         |
 | 2015-07-30 |            1 | 5M20 Era 1             | [ECIP-1017](https://ecips.ethereumclassic.org/ECIPs/ecip-1017) |
-| 2015-09-08 |      200,000 | Ice Age                | [EIP-684](https://github.com/ethereum/EIPs/issues/684)         |
+| 2015-09-08 |      200,000 | Ice Age                | [EIP-684](https://eips.ethereum.org/EIPS/684)         |
 | 2016-03-15 |    1,150,000 | Homestead              | [EIP-606](https://eips.ethereum.org/EIPS/eip-606)              |
 | 2016-10-24 |    2,500,000 | Gas Reprice            | [ECIP-1015](https://ecips.ethereumclassic.org/ECIPs/ecip-1015) |
 | 2017-01-13 |    3,000,000 | Die Hard               | [ECIP-1010](https://ecips.ethereumclassic.org/ECIPs/ecip-1010) |
+| 2017-01-13 |    3,000,000 | Spurious Dragon        | [EIP-160](https://eips.ethereum.org/EIPS/eip-160) |
 | 2017-12-11 |    5,000,000 | Gotham                 | [ECIP-1017](https://ecips.ethereumclassic.org/ECIPs/ecip-1017) |
 | 2017-12-11 |    5,000,000 | Gotham                 | [ECIP-1039](https://ecips.ethereumclassic.org/ECIPs/ecip-1039) |
 | 2017-12-11 |    5,000,001 | 5M20 Era 2             | [ECIP-1017](https://ecips.ethereumclassic.org/ECIPs/ecip-1017) |


### PR DESCRIPTION
Updates to the "Ethereum Classic Network Description" which is the canonical description of ETC hard forks.

- Added missing entry for EIP-160 (Spurious Dragon for ETC)
- Minor fix to URL for EIP-684.

We could really use proper "Meta" ECIPs to record these early hardforks, but that is a task for another day.

- "Gas Reprice" (ETC's Tangerine Whistle)
- "Die Hard" (ETC's Spurious Dragon and difficulty bomb delay)
- "Gotham" (Fixed monetary policy)
- "Defuse Difficulty Bomb"