### PR TITLE
atoulme ECIP Editor resignation

### DIFF
--- a/_specs/ecip-1000.md
+++ b/_specs/ecip-1000.md
@@ -72,14 +72,13 @@ A good reason to transfer ownership is because the original author no longer has
 
 Current ECIP editors:
 
-
-* @atoulme - Antoine Toulme, Independent
-* @gitr0n1n - r0n1n, Independent
 * @IstoraMandiri - Istora Mandiri, Independent
+* @gitr0n1n - r0n1n, Ethereum Classic DAO
 * @meowsbits - Mr. Meows D. Bits, ETC Cooperative Staff
 
 Former ECIP editors:
 
+* @atoulme - Antoine Toulme
 * @BelfordZ - Zachary Belford
 * @faraggi - Felipe Faraggi
 * @realcodywburns - Cody Burns


### PR DESCRIPTION
Source: https://github.com/ethereumclassic/ECIPs/issues/505

- Move atoulme to Former editors list.
+ Add r0n1n's public ETC-centric organization.

@realcodywburns will you remove @atoulme from @ethereumclassic/ecip-editors access? Also while you're in there can you double check permissions in the repo and remove stale/inactive accounts that may have access due to involvement in the past? Much thanks!