### PR TITLE
.github/workflows: use upgraded ruby setup github action

### DIFF
--- a/.github/workflows/ecip_validation.yml
+++ b/.github/workflows/ecip_validation.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6.10
     - name: Validate the ECIP spec files
       run: |
         gem install bundler


### PR DESCRIPTION
Should fix the error here
https://github.com/ethereumclassic/ECIPs/actions/runs/4413046760/jobs/7733097142?pr=504

Reported here https://github.com/ethereumclassic/ECIPs/pull/504#issuecomment-1505696710

