### PR TITLE
Move ecip-1047.md to Deferred Status

### DIFF
--- a/_specs/ecip-1047.md
+++ b/_specs/ecip-1047.md
@@ -3,7 +3,7 @@ lang: en
 ecip: 1047
 title: Reduce Gas Limit to 1 Million
 author: Anthony Lusardi (@pyskell)
-status: Deferred
+status: Withdrawn
 type: Informational
 created: 2019/1/3
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/14

--- a/_specs/ecip-1047.md
+++ b/_specs/ecip-1047.md
@@ -3,7 +3,7 @@ lang: en
 ecip: 1047
 title: Reduce Gas Limit to 1 Million
 author: Anthony Lusardi (@pyskell)
-status: Draft
+status: Rejected
 type: Informational
 created: 2019/1/3
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/14

--- a/_specs/ecip-1047.md
+++ b/_specs/ecip-1047.md
@@ -3,7 +3,7 @@ lang: en
 ecip: 1047
 title: Reduce Gas Limit to 1 Million
 author: Anthony Lusardi (@pyskell)
-status: Rejected
+status: Deferred
 type: Informational
 created: 2019/1/3
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/14


### PR DESCRIPTION
2023 Update: This was accidentally observed on the network due to a large mining pool setting their default gas to this level. This prevented the development community from the ability to deploy Smart Contracts to Ethereum Classic briefly. Once observed, it was corrected and the mining pool set their gas limit to 8M. 

Additionally over three years, seems stale and dated.

ECIP-1000
"ECIPs should be changed from Draft or Last Call status, to Rejected, upon request by any person, if they have not made progress in three years. Such a ECIP may be changed to Draft status if the champion provides revisions that meaningfully address public criticism of the proposal, or to Last Call if it meets the criteria required as described in the previous paragraph."

https://github.com/ethereumclassic/ECIPs/issues/14
https://github.com/ethereumclassic/ECIPs/issues/253#issuecomment-894449165