### PR TITLE
Update ecip-1109.md to Last Call status

### DIFF
--- a/_specs/ecip-1109.md
+++ b/_specs/ecip-1109.md
@@ -2,7 +2,7 @@
 lang: en
 ecip: 1109
 title: Spiral EVM and Protocol Upgrades
-status: Draft
+status: Last Call
 type: Meta
 author: Christos Ziogas <chris@etccooperative.org>, Diego López León <diego@etccooperative.org>, Isaac Ardis <isaac@etccooperative.org>
 created: 2023-05-10


### PR DESCRIPTION
Following ECIP-1000 procedure:
Change the status of ECIP-1109 to `Last Call` after the developers call yesterday where a mainnet block was selected/agreed upon. Note: there was no observed opposition/criticism to this proposal or the timeline of activation. https://www.youtube.com/watch?v=psEzr2SmUpo

I propose this ECIP sits in Last Call until Dec 31 (~3 weeks) for a review period. The core-geth client should be released in this timeframe.

Should everything be functioning properly, then move to `Accepted` status if there is no reason to revert to `Draft`, like discovery of error/bug in working client or something of the sort.

I'm open to adjusting any dates laid out here. These are simply an initial workflow suggestion in an effort to document and follow the status change track laid out in ECIP-1000.