### PR TITLE
ECBP-1110: Deactivate MESS

### DIFF
--- a/_specs/ecip-1100.md
+++ b/_specs/ecip-1100.md
@@ -4,7 +4,7 @@ title: MESS (Modified Exponential Subjective Scoring)
 lang: en
 author: Isaac <b5c6@protonmail.com>
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/374
-status: Active
+status: Replaced
 type: Standards Track
 category: ECBP
 created: 2020-09-09
@@ -14,6 +14,8 @@ license: Apache-2
 ## Abstract
 
 Define a function arbitrating chain acceptance using relative total difficulty and common ancestor time to raise finality confidence.
+
+_Update (January 2024):_ Replaced with [ECBP-1110](https://ecips.ethereumclassic.org/ECIPS/ecip-1110).
 
 ## Motivation
 

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -31,6 +31,10 @@ An override flag for this decision will be provided to configure ongoing operati
 
 Users will be encouraged to upgrade to Core-Geth v1.12.17, or to deactivate MESS manually, which can be done with all versions of core-geth implementing MESS using the flag value: `--ecbp1100=99999999999` or equivalent.
 
+### Mordor (ETC PoW Testnet)
+
+MESS will be deactivated at block `10,400,000`.
+
 ## Rationale
 
 While limited data circumscribes our understanding of hashrate supply, an apparent migration of an original roughly 1000 TH/s economy to currently about 20% of that, it seems reasonable to conclude that the costs of MESS now outweigh the risks it was designed to mitigate, since ETC's current hashrate accounts for around 85% of the apparent hashrate supply.

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -1,8 +1,8 @@
 ---
 ecip: 1110
-title: Disable MESS (Modified Exponential Subjective Scoring)
+title: Deactivate MESS (Modified Exponential Subjective Scoring)
 lang: en
-author: Isaac <b5c6@protonmail.com>
+author: Isaac <isaac@etccooperative.org>
 discussions-to: TODO
 status: Active
 type: Standards Track
@@ -13,25 +13,31 @@ license: Apache-2
 
 ## Abstract
 
-Turn off the artificial finality mechanism MESS (Modified Exponential Scoring) in Core-Geth (https://github.com/etclabscore/core-geth) for Ethereum Classic.
+Turn off the artificial finality mechanism [ECBP-1100's MESS (Modified Exponential Scoring)](/_specs/ecip-1100.md) in Core-Geth (https://github.com/etclabscore/core-geth) for Ethereum Classic.
 
 ## Motivation
 
-MESS was designed as a peripheral patch on the incumbent GHOST-based chain arbitration algorithm. It was intended to mitigate the risk imparted to the chain by an adjacent chain -- the Ethereum mainnet -- which, while using its original PoW algorithm, dwarfed ETC's hashrate and thus established the vulnerable position MESS hoped to safeguard. ETH has now, since April of this year, moved from PoW to PoS, and its exit from the PoW economy has left ETC as the largest sink of compatible hashrate (limited by DAG and the hash type demand).
+MESS was designed from the start as a temporary, peripheral patch on the incumbent GHOST-based chain arbitration algorithm.
+
+It was intended to mitigate the risk imparted to the chain by an adjacent chain -- the Ethereum mainnet -- which, while using its original PoW algorithm, dwarfed ETC's hashrate and thus established the vulnerable position MESS hoped to safeguard. ETH moved from PoW to PoS in September 2022. Its exit from the PoW economy has left ETC as the largest apparent sink of compatible hashrate (limited by DAG and the hash type demand). With this clear reduction in apparent risk to the network, the need for MESS is diminished.
+
+The costs of persisting any kind of subjective chain arbitration on the network are not zero. Network risk to sophisticated bifurcation attacks; an expected low-probability exposure to catastrophic failure. Code overhead during upstream codebase merges; developer chore cost.
 
 ## Specification
 
-MESS will be disabled by default in Core-Geth vX.Y.Z. 
+MESS will be deactivated by default at block `19,250,000`. This is concurrent with [ECIP-1109's Spiral Hardfork](/_specs/ecip-1109.md).
 
-An override flag for this decision will be provided to re-establish its normal operation. 
+An override flag for this decision will be provided to configure ongoing operation `--override.ecbp1100-deactivate=<number>`.
 
-Users will be encouraged to upgrade or disable MESS manually (which can be done with all versions of core-geth having MESS, using the flag value: `--ecbp1100 99999999999` or equivalent).
+Users will be encouraged to upgrade to Core-Geth v1.12.17, or to deactivate MESS manually, which can be done with all versions of core-geth implementing MESS using the flag value: `--ecbp1100=99999999999` or equivalent.
 
 ## Rationale
 
-While limited data circumscribes our understanding of the migration of the original roughly 1000 TH/s in the economy to a current value about 20% of that, it seems reasonable to conclude that the risks exposed by MESS now outweigh the risks it was designed to mitigate, since ETC accounts for around 80% of the current visible global rate.
+While limited data circumscribes our understanding of hashrate supply, an apparent migration of an original roughly 1000 TH/s economy to currently about 20% of that, it seems reasonable to conclude that the costs of MESS now outweigh the risks it was designed to mitigate, since ETC's current hashrate accounts for around 85% of the apparent hashrate supply.
 
 ## Implementation
+
+As far as I understand, the Core-Geth client is the only client to have implemented ECBP-1100, making it the only client that needs to implement deactivation.
 
 ## Testing
 

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -1,0 +1,38 @@
+---
+ecip: 1110
+title: Disable MESS (Modified Exponential Subjective Scoring)
+lang: en
+author: Isaac <b5c6@protonmail.com>
+discussions-to: TODO
+status: Active
+type: Standards Track
+category: ECBP
+created: 2023-09-17
+license: Apache-2
+---
+
+## Abstract
+
+Turn off the artificial finality mechanism MESS (Modified Exponential Scoring) in Core-Geth (https://github.com/etclabscore/core-geth) for Ethereum Classic.
+
+## Motivation
+
+MESS was designed as a peripheral patch on the incumbent GHOST-based chain arbitration algorithm. It was intended to mitigate the risk imparted to the chain by an adjacent chain -- the Ethereum mainnet -- which, while using its original PoW algorithm, dwarfed ETC's hashrate and thus established the vulnerable position MESS hoped to safeguard. ETH has now, since April of this year, moved from PoW to PoS, and its exit from the PoW economy has left ETC as the largest sink of compatible hashrate (limited by DAG and the hash type demand).
+
+## Specification
+
+MESS will be disabled by default in Core-Geth vX.Y.Z. 
+
+An override flag for this decision will be provided to re-establish its normal operation. 
+
+Users will be encouraged to upgrade or disable MESS manually (which can be done with all versions of core-geth having MESS, using the flag value: `--ecbp1100 99999999999` or equivalent).
+
+## Rationale
+
+While limited data circumscribes our understanding of the migration of the original roughly 1000 TH/s in the economy to a current value about 20% of that, it seems reasonable to conclude that the risks exposed by MESS now outweigh the risks it was designed to mitigate, since ETC accounts for around 80% of the current visible global rate.
+
+## Implementation
+
+## Testing
+
+## References

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -3,7 +3,7 @@ ecip: 1110
 title: Deactivate MESS (Modified Exponential Subjective Scoring)
 lang: en
 author: Isaac <isaac@etccooperative.org>
-discussions-to: TODO
+discussions-to: https://github.com/ethereumclassic/ECIPs/issues/521
 status: Active
 type: Standards Track
 category: ECBP

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -13,7 +13,7 @@ license: Apache-2
 
 ## Abstract
 
-Turn off the artificial finality mechanism [ECBP-1100's MESS (Modified Exponential Scoring)](/_specs/ecip-1100.md) in Core-Geth (https://github.com/etclabscore/core-geth) for Ethereum Classic.
+Turn off the artificial finality mechanism [ECBP-1100's MESS (Modified Exponential Scoring)](/_specs/ecip-1100.md) in [Core-Geth](https://github.com/etclabscore/core-geth) for Ethereum Classic.
 
 ## Motivation
 

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -3,7 +3,7 @@ ecip: 1110
 title: Deactivate MESS (Modified Exponential Subjective Scoring)
 lang: en
 author: Isaac <isaac@etccooperative.org>
-discussions-to: https://github.com/ethereumclassic/ECIPs/issues/521
+discussions-to: https://github.com/orgs/ethereumclassic/discussions/522
 status: Active
 type: Standards Track
 category: ECBP


### PR DESCRIPTION
Turn off the artificial finality mechanism [ECBP-1100's MESS (Modified Exponential Scoring)](https://ecips.ethereumclassic.org/ECIPs/ecip-1100) in [Core-Geth](https://github.com/etclabscore/core-geth) for Ethereum Classic.

Rendered document: https://github.com/meowsbits/ECIPs/blob/ecbp1110/_specs/ecip-1110.md

FYI I'll also be updating https://meowsbits.github.io/51-percent-docs/ this week, which provides some useful context.