### PR TITLE
Fix/ecip validation bundler version

### DIFF
--- a/.github/workflows/ecip_validation.yml
+++ b/.github/workflows/ecip_validation.yml
@@ -13,6 +13,6 @@ jobs:
         ruby-version: 2.6.10
     - name: Validate the ECIP spec files
       run: |
-        gem install bundler
+        gem install bundler -v 2.4.22
         bundle install --jobs 4 --retry 3
         shopt -s globstar; bundle exec ecip_validator _specs/**/*.md

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "html-proofer", '>=3.3.1'
 
-gem 'ecip_validator', '>= 0.9.0'
+gem 'ecip_validator', '>= 0.10.0'
 
 # Rel issue: https://github.com/ethereumclassic/ECIPs/pull/308#issuecomment-618044919
 gem 'faraday', '~> 0.17.3'

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "html-proofer", '>=3.3.1'
 
+# https://rubygems.org/gems/ecip_validator
+# https://github.com/meowsbits/ecip_validator
 gem 'ecip_validator', '>= 0.10.0'
 
 # Rel issue: https://github.com/ethereumclassic/ECIPs/pull/308#issuecomment-618044919


### PR DESCRIPTION
https://github.com/ethereumclassic/ECIPs/actions/runs/7463320371
`ecip_validator` actions were failing because of a `bundler` version error.

Then, `ecip-1100.md` was failing validation because `Replaced` did not exist in the list of valid statuses at the `ecip_validator`, so I patched that and bumped the version for that here too.

https://github.com/meowsbits/ecip_validator
https://rubygems.org/gems/ecip_validator