### PR TITLE
.github/workflows: fix jekyll build issue

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -14,4 +14,4 @@ jobs:
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:3 /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+        jekyll/builder:3 /bin/bash -c "chmod a+w /srv/jekyll/Gemfile.lock && chmod 777 /srv/jekyll && jekyll build --future"


### PR DESCRIPTION
Issue noticed here: https://github.com/ethereumclassic/ECIPs/pull/524
This CI issue: https://github.com/ethereumclassic/ECIPs/actions/runs/7514278707/job/20456978667?pr=524
According to this, might fix it: https://stackoverflow.com/questions/63435125/github-jekyll-workflow-failure