### PR TITLE
Refine ECIP-1115: Clarify Governance-Layer Scope, Invariants, and Optionality

### DIFF
--- a/_specs/ecip-1115.md
+++ b/_specs/ecip-1115.md
@@ -74,7 +74,7 @@ The smoothing model defines only the timing and magnitude of intended allocation
 
 #### 3. Allocation Rule
 
-For each block `k`, the smoothing mechanism produces a sequence of intended allocations `A(k + j)` for `j = 1…N`, as defined in Section 2. These allocations represent scheduled values that MAY be used as inputs to standard Treasury withdrawal semantics after approval via the governance pipeline defined in ECIP-1113 and ECIP-1114.
+For each block *k*, the smoothing mechanism produces a sequence of intended allocations `A(k + j)` for `j = 1…N`, as defined in Section 2. These allocations represent scheduled values that MAY be used as inputs to standard Treasury withdrawal semantics after approval via the governance pipeline defined in ECIP-1113 and ECIP-1114.
 
 Smoothing defines only the schedule of intended payouts; it does not create rights, claims, reservations, implied obligations, or automatic execution. All payouts MUST be explicitly authorized by governance through the OIP process or through a governance-approved smoothing module that prepares Treasury withdrawal calls conforming to ECIP-1114.
 


### PR DESCRIPTION
This PR refines ECIP-1115 to clarify its governance-layer scope, invariants, and optionality, ensuring full alignment with ECIPs 1111–1114 and ECIP-1000 standards. The update adds explicit guarantees about determinism, Treasury immutability, module behavior, and default-off activation while removing any ambiguity around rights, entitlements, or consensus-layer effects. These changes make ECIP-1115 fully modular, misinterpretation-resistant, and ready for final review.