### PR TITLE
Add Diego López León as Co-Author of ECIP-1115 (Miner Incentive Smoothing)

### DIFF
--- a/_specs/ecip-1115.md
+++ b/_specs/ecip-1115.md
@@ -5,7 +5,7 @@ title: Olympia L-Curve Smoothing for Long-Term Network Security
 status: Draft
 type: Meta
 requires: 1111, 1112, 1113, 1114
-author: Cody Burns (@realcodywburns), Chris Mercer (@chris-mercer)
+author: Diego López León (@diega), Cody Burns (@realcodywburns), Chris Mercer (@chris-mercer)
 created: 2025-11-15
 discussions-to: https://github.com/orgs/ethereumclassic/discussions/530
 license: CC0-1.0


### PR DESCRIPTION
This PR updates the ECIP-1115 draft to include Diego López León as a co-author alongside Cody Burns and Chris Mercer.

Diego initiated the L-curve smoothing concept, participated in its early modeling concepts, and contributed to the technical rationale discussed in Community Calls 041–042. Adding him to the author field properly credits his role in the development of the smoothing approach, the long-term network security budget considerations, and brings the draft in line with ECIP-1000 authorship expectations.

No changes are made to the specification logic or technical content.
