### PR TITLE
ECIP (draft) - Elysium Basefee Split Routing

### DIFF
--- a/_specs/ecip-1110-ely-fee.md
+++ b/_specs/ecip-1110-ely-fee.md
@@ -1,0 +1,125 @@
+---
+ecip: 1110-ELY-FEE
+title: Elysium Fee Market and Productive Revenue Routing
+lang: en
+author: Daniel Tocila
+status: Draft
+type: Standards Track
+category: Core
+created: 2026-03-11
+license: Apache-2
+---
+
+## Abstract
+
+This ECIP activates the fee market changes specified in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) and the `BASEFEE` opcode specified in [EIP-3198](https://eips.ethereum.org/EIPS/eip-3198) on Ethereum Classic.
+
+Unlike Ethereum (where `BASEFEE` is burned), this ECIP redirects the protocol-collected `BASEFEE` amount to a deterministic Elysium Revenue Contract address.
+
+## Simple Summary
+
+Elysium provides modern fee-market compatibility for ETC while preserving Proof-of-Work and fixed issuance.
+Miner `priorityFee` remains payable directly to block producers.
+The `BASEFEE` portion is redirected to a deterministic, protocol-owned Elysium revenue address intended to support productive, auditable settlement modules rather than passive accumulation.
+
+## Motivation
+
+Ethereum Classic benefits from execution-layer compatibility with the broader EVM ecosystem.
+If ETC activates London-style fee market behavior, it must also choose how `BASEFEE` is handled.
+
+Elysium proposes a productive revenue-routing model: protocol revenue should be routed into a deterministic contract address intended to support auditable utility generation rather than a passive balance.
+
+## Specification
+
+This ECIP:
+
+- Activates [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) on Ethereum Classic.
+- Activates [EIP-3198](https://eips.ethereum.org/EIPS/eip-3198) on Ethereum Classic.
+- Redirects all `BASEFEE`-denominated fee revenue to the Elysium Revenue Contract address (instead of burning it).
+- Preserves direct miner receipt of `priorityFee`.
+- Preserves ETC monetary policy and issuance schedule (no changes to block subsidy or issuance).
+- Excludes Proof-of-Stake-specific features.
+
+### Activation
+
+Activation block numbers are **TBD** pending coordination and testnet deployment.
+
+- **Mordor**: TBD
+- **Ethereum Classic Mainnet**: TBD
+
+### Elysium Revenue Address
+
+Let `ELYSIUM_REVENUE_ADDRESS` be an address agreed upon prior to activation.
+
+- `ELYSIUM_REVENUE_ADDRESS`: **TBD**
+
+This ECIP does not require code to exist at `ELYSIUM_REVENUE_ADDRESS` at the activation block. If no code is present, the address behaves as a normal EOA-style account for balance accounting purposes (i.e., it can still accrue balance).
+
+### Consensus Rules
+
+Clients MUST implement EIP-1559 and EIP-3198 as specified, with the sole Ethereum-Classic-specific modification described below.
+
+#### BASEFEE redirection (ETC-specific modification)
+
+Where EIP-1559 specifies that the `BASEFEE` portion of transaction fees is burned, clients MUST instead credit that amount to `ELYSIUM_REVENUE_ADDRESS`.
+
+Informally, for each transaction $i$ in a block with gas used $g_i$ and block base fee $b$ (in wei per gas), define:
+
+$$
+	ext{basefee\_revenue} = \sum_i g_i \cdot b
+$$
+
+Then the post-state transition for the block MUST include:
+
+- `balance[ELYSIUM_REVENUE_ADDRESS] += basefee_revenue`
+
+All other EIP-1559 behaviors remain unchanged, including:
+
+- `BASEFEE` calculation and validity rules.
+- The `BASEFEE` field in the block header.
+- The computation and payment of `priorityFee` to the block beneficiary (coinbase).
+- Transaction validity rules for `maxFeePerGas` and `maxPriorityFeePerGas`.
+
+## Companion Contract Scope Note
+
+This ECIP defines only `BASEFEE` redirection to the deterministic Elysium revenue address.
+Distribution mechanics (including potential multi-destination routing) are out of scope for this ECIP and are expected to be specified in a companion ECIP (draft).
+
+## Symbolic Placeholder IDs (Olympia-relative, non-final)
+
+The identifiers below are symbolic placeholders.
+
+- ECIP-1110-ELY-FEE (this document): Elysium Fee Market and Productive Revenue Routing
+- ECIP-1111-ELY-REV: Elysium Revenue Contract
+- ECIP-1112-ELY-COMP (informational companion): Elysium logtrees/logN Productive Settlement Overview
+
+## Rationale
+
+This proposal preserves Ethereum Classic’s compatibility direction while offering a different sink for redirected `BASEFEE`.
+The intended sink is not a passive treasury, but a deterministic contract address intended to support auditable, utility-generating settlement modules.
+
+## Backwards Compatibility
+
+This ECIP introduces a hard fork.
+Clients that do not implement this ECIP will diverge from the canonical Ethereum Classic chain at the designated activation block.
+
+## Security Considerations
+
+This ECIP does not place subjective verification inside consensus.
+Consensus changes are limited to fee-market behavior and deterministic `BASEFEE` revenue routing.
+Any application-layer verification, scoring, estimation, or reward logic must be modular, separately auditable, and non-consensus.
+
+## Implementation
+
+This ECIP requires changes in ETC clients implementing the EVM and state transition function to:
+
+- Introduce EIP-1559 and EIP-3198 at the agreed activation blocks.
+- Replace the EIP-1559 `BASEFEE` burn behavior with a balance credit to `ELYSIUM_REVENUE_ADDRESS`.
+
+## Reference Implementation Status
+
+Companion documents may describe existing logtrees/logN prototype work. That work is illustrative and non-normative unless explicitly incorporated into consensus-client code.
+
+## Copyright/Licensing
+
+This document is licensed under Apache-2.

--- a/_specs/ecip-1110-ely-fee.md
+++ b/_specs/ecip-1110-ely-fee.md
@@ -14,20 +14,20 @@ license: Apache-2
 
 This ECIP activates the fee market changes specified in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) and the `BASEFEE` opcode specified in [EIP-3198](https://eips.ethereum.org/EIPS/eip-3198) on Ethereum Classic.
 
-Unlike Ethereum (where `BASEFEE` is burned), this ECIP redirects the protocol-collected `BASEFEE` amount to a deterministic Elysium Revenue Contract address.
+Unlike Ethereum (where `BASEFEE` is burned), this ECIP routes `97%` of the protocol-collected `BASEFEE` amount to the block beneficiary and `1%` each to deterministic addresses for Core ETC, ETC Grants, and logtrees.
 
 ## Simple Summary
 
 Elysium provides modern fee-market compatibility for ETC while preserving Proof-of-Work and fixed issuance.
 Miner `priorityFee` remains payable directly to block producers.
-The `BASEFEE` portion is redirected to a deterministic, protocol-owned Elysium revenue address intended to support productive, auditable settlement modules rather than passive accumulation.
+The `BASEFEE` portion is split so that block producers receive `97%`, while Core ETC, ETC Grants, and logtrees each receive `1%` through deterministic protocol-routed addresses.
 
 ## Motivation
 
 Ethereum Classic benefits from execution-layer compatibility with the broader EVM ecosystem.
 If ETC activates London-style fee market behavior, it must also choose how `BASEFEE` is handled.
 
-Elysium proposes a productive revenue-routing model: protocol revenue should be routed into a deterministic contract address intended to support auditable utility generation rather than a passive balance.
+Elysium proposes a miner-aligned productive revenue-routing model: most protocol revenue remains with the block producer, while three small deterministic shares are routed to Core ETC, ETC Grants, and logtrees.
 
 ## Specification
 
@@ -35,7 +35,7 @@ This ECIP:
 
 - Activates [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) on Ethereum Classic.
 - Activates [EIP-3198](https://eips.ethereum.org/EIPS/eip-3198) on Ethereum Classic.
-- Redirects all `BASEFEE`-denominated fee revenue to the Elysium Revenue Contract address (instead of burning it).
+- Routes `97%` of `BASEFEE`-denominated fee revenue to the block beneficiary and `1%` each to deterministic addresses for Core ETC, ETC Grants, and logtrees (instead of burning it).
 - Preserves direct miner receipt of `priorityFee`.
 - Preserves ETC monetary policy and issuance schedule (no changes to block subsidy or issuance).
 - Excludes Proof-of-Stake-specific features.
@@ -47,31 +47,56 @@ Activation block numbers are **TBD** pending coordination and testnet deployment
 - **Mordor**: TBD
 - **Ethereum Classic Mainnet**: TBD
 
-### Elysium Revenue Address
+### Elysium Routing Addresses
 
-Let `ELYSIUM_REVENUE_ADDRESS` be an address agreed upon prior to activation.
+Let the following addresses be agreed upon prior to activation.
 
-- `ELYSIUM_REVENUE_ADDRESS`: **TBD**
+- `ELYSIUM_CORE_ETC_ADDRESS`: **TBD**
+- `ELYSIUM_ETC_GRANTS_ADDRESS`: **TBD**
+- `ELYSIUM_LOGTREES_ADDRESS`: **TBD**
 
-This ECIP does not require code to exist at `ELYSIUM_REVENUE_ADDRESS` at the activation block. If no code is present, the address behaves as a normal EOA-style account for balance accounting purposes (i.e., it can still accrue balance).
+This ECIP does not require code to exist at any of these addresses at the activation block. If no code is present, an address behaves as a normal EOA-style account for balance accounting purposes (i.e., it can still accrue balance).
 
 ### Consensus Rules
 
 Clients MUST implement EIP-1559 and EIP-3198 as specified, with the sole Ethereum-Classic-specific modification described below.
 
-#### BASEFEE redirection (ETC-specific modification)
+#### BASEFEE split routing (ETC-specific modification)
 
-Where EIP-1559 specifies that the `BASEFEE` portion of transaction fees is burned, clients MUST instead credit that amount to `ELYSIUM_REVENUE_ADDRESS`.
+Where EIP-1559 specifies that the `BASEFEE` portion of transaction fees is burned, clients MUST instead split that amount between the block beneficiary and the deterministic addresses for Core ETC, ETC Grants, and logtrees.
 
 Informally, for each transaction $i$ in a block with gas used $g_i$ and block base fee $b$ (in wei per gas), define:
 
 $$
-	ext{basefee\_revenue} = \sum_i g_i \cdot b
+\text{basefee\_revenue} = \sum_i g_i \cdot b
 $$
 
-Then the post-state transition for the block MUST include:
+Then define:
 
-- `balance[ELYSIUM_REVENUE_ADDRESS] += basefee_revenue`
+$$
+\text{core\_etc\_share} = \left\lfloor \frac{\text{basefee\_revenue}}{100} \right\rfloor
+$$
+
+$$
+\text{etc\_grants\_share} = \left\lfloor \frac{\text{basefee\_revenue}}{100} \right\rfloor
+$$
+
+$$
+\text{logtrees\_share} = \left\lfloor \frac{\text{basefee\_revenue}}{100} \right\rfloor
+$$
+
+$$
+\text{miner\_basefee\_share} = \text{basefee\_revenue} - \text{core\_etc\_share} - \text{etc\_grants\_share} - \text{logtrees\_share}
+$$
+
+Any remainder produced by integer division MUST remain with the block beneficiary through `miner_basefee_share`.
+
+Then the post-state transition for the block MUST include, in addition to normal `priorityFee` handling:
+
+- `balance[block.beneficiary] += miner_basefee_share`
+- `balance[ELYSIUM_CORE_ETC_ADDRESS] += core_etc_share`
+- `balance[ELYSIUM_ETC_GRANTS_ADDRESS] += etc_grants_share`
+- `balance[ELYSIUM_LOGTREES_ADDRESS] += logtrees_share`
 
 All other EIP-1559 behaviors remain unchanged, including:
 
@@ -80,23 +105,23 @@ All other EIP-1559 behaviors remain unchanged, including:
 - The computation and payment of `priorityFee` to the block beneficiary (coinbase).
 - Transaction validity rules for `maxFeePerGas` and `maxPriorityFeePerGas`.
 
-## Companion Contract Scope Note
+## Companion Scope Note
 
-This ECIP defines only `BASEFEE` redirection to the deterministic Elysium revenue address.
-Distribution mechanics (including potential multi-destination routing) are out of scope for this ECIP and are expected to be specified in a companion ECIP (draft).
+This ECIP defines the consensus-layer `97%`/`1%`/`1%`/`1%` routing of `BASEFEE` between the block beneficiary and the deterministic addresses for Core ETC, ETC Grants, and logtrees.
+Any downstream custody, settlement, grants, or logtrees-specific logic for the three `1%` shares is out of scope for this ECIP and is expected to be specified in companion documents or recipient-specific operational documents.
 
 ## Symbolic Placeholder IDs (Olympia-relative, non-final)
 
 The identifiers below are symbolic placeholders.
 
 - ECIP-1110-ELY-FEE (this document): Elysium Fee Market and Productive Revenue Routing
-- ECIP-1111-ELY-REV: Elysium Revenue Contract
+- ECIP-1111-ELY-REV: Elysium Revenue Routing Destinations
 - ECIP-1112-ELY-COMP (informational companion): Elysium logtrees/logN Productive Settlement Overview
 
 ## Rationale
 
-This proposal preserves Ethereum Classic’s compatibility direction while offering a different sink for redirected `BASEFEE`.
-The intended sink is not a passive treasury, but a deterministic contract address intended to support auditable, utility-generating settlement modules.
+This proposal preserves Ethereum Classic’s compatibility direction while keeping miners as the primary recipient of fee-market revenue.
+The remaining `3%` is split across Core ETC, ETC Grants, and logtrees as small deterministic allocations.
 
 ## Backwards Compatibility
 
@@ -106,7 +131,7 @@ Clients that do not implement this ECIP will diverge from the canonical Ethereum
 ## Security Considerations
 
 This ECIP does not place subjective verification inside consensus.
-Consensus changes are limited to fee-market behavior and deterministic `BASEFEE` revenue routing.
+Consensus changes are limited to fee-market behavior and deterministic `BASEFEE` split routing.
 Any application-layer verification, scoring, estimation, or reward logic must be modular, separately auditable, and non-consensus.
 
 ## Implementation
@@ -114,7 +139,7 @@ Any application-layer verification, scoring, estimation, or reward logic must be
 This ECIP requires changes in ETC clients implementing the EVM and state transition function to:
 
 - Introduce EIP-1559 and EIP-3198 at the agreed activation blocks.
-- Replace the EIP-1559 `BASEFEE` burn behavior with a balance credit to `ELYSIUM_REVENUE_ADDRESS`.
+- Replace the EIP-1559 `BASEFEE` burn behavior with deterministic balance credits of `97%` to the block beneficiary and `1%` each to `ELYSIUM_CORE_ETC_ADDRESS`, `ELYSIUM_ETC_GRANTS_ADDRESS`, and `ELYSIUM_LOGTREES_ADDRESS`.
 
 ## Reference Implementation Status
 

--- a/_specs/ecip-tocila-elysium-basefee-split.md
+++ b/_specs/ecip-tocila-elysium-basefee-split.md
@@ -1,6 +1,6 @@
 ---
-ecip: 1110-ELY-FEE
-title: Elysium Fee Market and Productive Revenue Routing
+ecip: ?
+title: Elysium Basefee Split Routing
 lang: en
 author: Daniel Tocila
 status: Draft
@@ -110,13 +110,11 @@ All other EIP-1559 behaviors remain unchanged, including:
 This ECIP defines the consensus-layer `97%`/`1%`/`1%`/`1%` routing of `BASEFEE` between the block beneficiary and the deterministic addresses for Core ETC, ETC Grants, and logtrees.
 Any downstream custody, settlement, grants, or logtrees-specific logic for the three `1%` shares is out of scope for this ECIP and is expected to be specified in companion documents or recipient-specific operational documents.
 
-## Symbolic Placeholder IDs (Olympia-relative, non-final)
+## Draft Alias
 
-The identifiers below are symbolic placeholders.
+Until an ECIP editor assigns a number, this draft should use an alias-based filename rather than a pseudo-numbered identifier.
 
-- ECIP-1110-ELY-FEE (this document): Elysium Fee Market and Productive Revenue Routing
-- ECIP-1111-ELY-REV: Elysium Revenue Routing Destinations
-- ECIP-1112-ELY-COMP (informational companion): Elysium logtrees/logN Productive Settlement Overview
+- Draft alias: `ecip-tocila-elysium-basefee-split`
 
 ## Rationale
 


### PR DESCRIPTION
### Description

Elysium Basefee Split Routing proposes activating EIP-1559 and EIP-3198 behavior on Ethereum Classic while routing consensus `BASEFEE` to a deterministic Elysium revenue contract instead of burning it. The proposal preserves miner `priorityFee`, keeps ETC issuance policy intact, and defines a narrow consensus-surface change focused on fee-market compatibility plus deterministic productive routing.

This is part of the Elysium upgrade which is defined here in the Elysium Files: 

https://logtrees.com/elysium/elysium.html

For broader Elysium discussion, see this discussion: https://github.com/orgs/ethereumclassic/discussions/571

You can also ask us questions in Discord and we will be on the Community Calls!

---

### Front-Matter Checklist

Verify that your ECIP file's front-matter block contains all required fields per [ECIP-1000](_specs/ecip-1000.md):

- [x] `ecip:` — `1110`
- [x] `title:` — `Elysium Fee Market and Productive Revenue Routing`
- [x] `lang:` — `en`
- [x] `author:` — Real name(s) and optionally email address or GitHub handle
- [ ] `discussions-to:` — URL of the public discussion thread (Discord, GitHub issue, etc.)
- [x] `status:` — `Draft`
- [x] `type:` — `Standards Track`
- [x] `category:` — `Core`
- [x] `created:` — `2026-03-12`

### Section Checklist

Verify that your ECIP document contains all required sections:

- [x] `### Abstract` — Short (~200 word) description of the technical issue
- [x] `### Motivation` — Why the existing protocol is inadequate
- [x] `### Specification` — Precise technical specification of the proposed change
- [x] `### Rationale` — Design decisions, alternatives considered, and community consensus
- [x] `### Implementation` — Reference implementation or notes (currently captured via implementation status notes)
- [ ] `### Copyright/Licensing` — Explicit license terms (see ECIP-1000 for accepted licenses)

