### PR TITLE
Add ECIP-1130: Bastion EVM and Protocol Upgrades (Draft)

### DIFF
--- a/_specs/ecip-1130.md
+++ b/_specs/ecip-1130.md
@@ -1,0 +1,103 @@
+---
+lang: en
+ecip: 1130
+title: Bastion EVM and Protocol Upgrades
+author: Diego López León (@diega), Istora Mandiri (@IstoraMandiri)
+status: Draft
+type: Meta
+created: 2026-06-30
+discussions-to: https://github.com/orgs/ethereumclassic/discussions/575
+license: CC0-1.0
+---
+
+## Simple Summary
+
+Enable a subset of the Ethereum Foundation **Cancun**, **Prague** and **Osaka** execution-layer protocol upgrades on the Ethereum Classic network in a hard-fork code-named Bastion to enhance compatibility across these networks.
+
+## Abstract
+
+Add support for a subset of protocol-impacting changes introduced in the Ethereum Foundation (ETH) network via the *Cancun* (Mar 2024), *Prague* (May 2025) and *Osaka* (Dec 2025, the execution-layer half of "Fusaka") network upgrades. The proposed changes for Ethereum Classic's *Bastion* upgrade include:
+
+| EIP | Description | Status |
+| --- | --- | --- |
+| 1153 | Transient storage opcodes (`TLOAD` / `TSTORE`) | Include |
+| 5656 | `MCOPY` opcode | Include |
+| 6780 | `SELFDESTRUCT` only in same transaction | Include |
+| 2537 | Precompiles for BLS12-381 curve operations | Include |
+| 7823 | Set upper bounds for `MODEXP` inputs | Include |
+| 7883 | `MODEXP` gas cost increase | Include |
+| 7939 | `CLZ` opcode (count leading zeros) | Include |
+| 7951 | Precompile for secp256r1 (`P256VERIFY`) | Include |
+
+This document proposes the following blocks at which to implement these changes in the Ethereum Classic networks:
+
+- `TBD` on Mordor testnet
+- `TBD` on Ethereum Classic mainnet
+
+For more information on the opcodes, precompiles and their respective EIPs and implementations, please see the *Specification* section of this document.
+
+## EIP Summaries and expected action
+
+### Included
+
+- EIP-1153 "Transient storage opcodes": Adds `TLOAD` (`0x5C`) and `TSTORE` (`0x5D`), a per-transaction key/value store discarded at end of the top-level call frame.
+- EIP-5656 "MCOPY opcode": Adds `MCOPY` (`0x5E`), an efficient memory-to-memory copy instruction with `memmove` semantics.
+- EIP-6780 "SELFDESTRUCT only in same transaction": Restricts `SELFDESTRUCT` (`0xFF`) to delete account, storage and code only when the contract was created in the same transaction; otherwise only the balance is transferred.
+- EIP-2537 "BLS12-381 precompiles": Adds precompiles at `0x0B`–`0x12` exposing BLS12-381 G1/G2 add, MSM, pairing check and field-to-curve maps.
+- EIP-7823 "Upper bounds for MODEXP": Caps each `MODEXP` input at 1024 bytes; out-of-bounds calls consume all supplied gas and return failure.
+- EIP-7883 "MODEXP gas cost increase": Re-prices `MODEXP` with a minimum of 500 gas, a higher per-word multiplier for inputs > 32 bytes, and a doubled multiplication-complexity branch for inputs > 32 bytes. Paired with EIP-7823.
+- EIP-7939 "CLZ opcode": Adds `CLZ` (`0x1E`), returning the count of leading zero bits of a 256-bit word (256 if the operand is zero); 3 gas.
+- EIP-7951 "secp256r1 precompile": Adds `P256VERIFY` at `0x100`, verifying an ECDSA signature over NIST P-256 at a fixed cost of 6900 gas; enables WebAuthn / passkey signature verification on-chain.
+
+### Omitted (not applicable to ETC)
+
+The following EIPs from the source upgrades assume Proof-of-Stake, the Beacon Chain, blob data availability, or the EIP-1559 fee market — none of which ETC has adopted — and are therefore omitted from *Bastion*:
+
+- From *Cancun*: EIP-4788 (Beacon block root in the EVM), EIP-4844 (Shard Blob Transactions), EIP-7516 (BLOBBASEFEE).
+- From *Prague*: EIP-6110 (validator deposits on-chain), EIP-7002 (EL-triggerable exits), EIP-7251 (`MAX_EFFECTIVE_BALANCE`), EIP-7549 (committee index outside attestation), EIP-7685 (EL requests), EIP-7691 (blob throughput), EIP-7840 (blob schedule in EL config).
+- From *Osaka*: EIP-7594 (PeerDAS), EIP-7892 (blob parameter-only forks), EIP-7918 (blob base-fee floor).
+
+### Deferred (EL-applicable, but left for a follow-up ECIP)
+
+- EIP-2935 "Serve historical block hashes from state": the upstream motivation is to bundle historical block hashes into witnesses for stateless / Verkle clients, with a secondary use case of extending the history window available to rollups. ETC has not committed to a stateless transition and has no L2 rollup ecosystem consuming this surface; defer until the ETC stateless roadmap is defined.
+- EIP-7623 "Increase calldata cost": fee-market tuning anchored in EIP-1559 economics; ETC needs a native cost model under ECIP-1017 before adopting.
+- EIP-7702 "Set EOA account code": the authorization-cost schedule and gas accounting reference EIP-1559 + `BASEFEE`, which ETC did not adopt in *Mystique*; the upstream spec is still evolving (chain-id binding, nonce semantics, revocation flows) and the replay/sponsorship surface observed on Ethereum mainnet post-*Pectra* should be reviewed before adoption. Out of scope for *Bastion*; candidate for a follow-up ECIP.
+- EIP-7825 "Transaction gas limit cap": caps individual transactions at 2^24 (16,777,216) gas. The upstream motivation is anchored in Ethereum's growing block gas limit and in the throughput increases shipped through the blob / PeerDAS path — contexts in which a single unbounded transaction can monopolize a block. Ethereum Classic's block gas limit currently sits well below the proposed per-tx cap, and ETC has no blob path; the cap has no observable effect under present conditions. Defer until either ETC's block gas limit is raised above the EIP-7825 cap or a comparable throughput-expanding change is on the roadmap.
+- EIP-7935 "Default gas limit to 60M": advisory only; on ETC miners set the gas limit, so any default should be debated separately.
+
+## Motivation
+
+To extend the Ethereum Virtual Machine's (EVM) capabilities, various opcodes and precompiles shall be added to the Ethereum Classic networks, all of which have been in use on the Ethereum Foundation networks since the *Cancun* (March 2024), *Prague* (May 2025) and *Osaka* (December 2025) activations. This keeps Ethereum Classic at parity with the post-*Cancun* EVM consumed by Solidity, Vyper, Hardhat, Foundry, and audit tooling, and adds support for the BLS12-381 (ZK / threshold signatures) and secp256r1 (WebAuthn / passkeys) cryptographic primitives.
+
+EIP-7823 and EIP-7883 are included as a pair: adopting EIP-7883 alone leaves the bounded-input branch under-priced relative to current benchmarks, and adopting EIP-7823 alone retains the legacy pricing for unbounded inputs.
+
+## Specification
+
+Technical specifications for each EIP can be found at those documents respectively:
+
+- [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153): Transient storage opcodes
+- [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656): MCOPY — Memory copying instruction
+- [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780): SELFDESTRUCT only in same transaction
+- [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537): Precompile for BLS12-381 curve operations
+- [EIP-7823](https://eips.ethereum.org/EIPS/eip-7823): Set upper bounds for MODEXP
+- [EIP-7883](https://eips.ethereum.org/EIPS/eip-7883): MODEXP gas cost increase
+- [EIP-7939](https://eips.ethereum.org/EIPS/eip-7939): Count leading zeros (CLZ) opcode
+- [EIP-7951](https://eips.ethereum.org/EIPS/eip-7951): Precompile for secp256r1 curve support
+
+## Rationale
+
+**Interoperability**: Maintaining interoperable behavior between Ethereum clients reduces friction for developers and end-users across the participating chains (e.g., ETH and ETC, Sepolia / Hoodi and Mordor).
+
+**Immutability**: New opcodes (`TLOAD`, `TSTORE`, `MCOPY`, `CLZ`) occupy previously-invalid opcode slots, and new precompiles (BLS12-381 range, `P256VERIFY`) occupy previously-empty addresses; none of them can alter the behavior of existing contracts.
+
+**Continuation of the SELFDESTRUCT deprecation**: EIP-6780 is the operational follow-up to EIP-6049, which Ethereum Classic adopted in *Spiral* ([ECIP-1109](https://ecips.ethereumclassic.org/ECIPs/ecip-1109)). EIP-6049 formally deprecated `SELFDESTRUCT` and signalled to developers that future hard-forks would change its behavior; EIP-6780 is the first such change. The opcode is preserved, balance transfer is preserved, and the change is limited to the post-creation state-deletion path — for contracts that were *not* created in the current transaction, `SELFDESTRUCT` becomes a balance-transfer instruction. The narrowed semantics have been live on Ethereum mainnet since the *Dencun* activation in March 2024 with no recorded production incidents tied to the change.
+
+**No fee-market change**: *Bastion* does not alter base fees, blob fees, or calldata gas, consistent with *Mystique*'s position on EIP-1559 and ETC's monetary policy (ECIP-1017).
+
+## Implementation
+
+_To be completed._ Reference implementations will be linked from the respective Ethereum Classic execution clients as the change set is developed. Each included EIP already has reference implementations in the upstream Ethereum execution-layer clients, listed in the *Specification* section above.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## ECIP Submission

Proposes **ECIP-1130: Bastion EVM and Protocol Upgrades** — a Meta ECIP defining the *Bastion* hard fork, which brings a subset of Ethereum's *Cancun*, *Prague* and *Osaka* execution-layer EIPs to Ethereum Classic.

### Front-Matter Checklist

- [x] `ecip:` — `1130`
- [x] `title:` — Bastion EVM and Protocol Upgrades
- [x] `lang:` — `en`
- [x] `author:` — Diego López León (@diega), Istora Mandiri (@IstoraMandiri)
- [x] `discussions-to:` — https://github.com/orgs/ethereumclassic/discussions/575
- [x] `status:` — `Draft`
- [x] `type:` — `Meta`
- [ ] `category:` — N/A (only required for `Standards Track`)
- [x] `created:` — `2026-05-13`

### Section Checklist

- [x] `## Abstract`
- [x] `## Motivation`
- [x] `## Specification`
- [x] `## Rationale`
- [x] `## Implementation` (placeholder; to be completed before `Final`)
- [x] `## Copyright` — CC0-1.0

### Description

Bastion adds the following EL EIPs to ETC: **1153** (transient storage), **5656** (`MCOPY`), **6780** (`SELFDESTRUCT` same-tx), **2537** (BLS12-381 precompiles), **7823** + **7883** (`MODEXP` bounds & repricing), **7939** (`CLZ`), and **7951** (secp256r1 `P256VERIFY`).

EIPs that assume Proof-of-Stake, the Beacon Chain, blob data availability, or the EIP-1559 fee market are omitted, and several EL-applicable EIPs (2935, 7623, 7702, 7825, 7935) are deferred to a follow-up ECIP. No fee-market changes are introduced, consistent with *Mystique* and ECIP-1017.

Activation blocks for Mordor and mainnet are still `TBD` pending the fork schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
