### PR TITLE
spec(ecip-1100,1110): ECBP-1100 is Active not Replaced

### DIFF
--- a/_specs/ecip-1100.md
+++ b/_specs/ecip-1100.md
@@ -15,7 +15,7 @@ license: Apache-2
 
 Define a function arbitrating chain acceptance using relative total difficulty and common ancestor time to raise finality confidence.
 
-_Update (January 2024):_ Replaced with [ECBP-1110](https://ecips.ethereumclassic.org/ECIPs/ecip-1110).
+_Update (January 2024):_ [ECBP-1110](https://ecips.ethereumclassic.org/ECIPs/ecip-1110) turned the bundled default off. The mechanism remains in the client and available to any operator who enables it.
 
 ## Motivation
 
@@ -39,15 +39,13 @@ What follows is an algorithm and implementation details toward a way to realize 
 
 - > Small reorgs are normal and healthy; large reorgs are suspicious.
 
-Conceptions of "small" and "large" are described functionally by the "suspicious" curve; a reorg becomes "big" when it becomes suspicious, and vice versa. This is parameterized by time and total difficulty. Generally, anything less than about 10 minutes won't be suspicious, and thus is considered "small." 
+Conceptions of "small" and "large" are described functionally by the "suspicious" curve; a reorg becomes "big" when it becomes suspicious, and vice versa. This is parameterized by time and total difficulty. Generally, anything less than about 10 minutes won't be suspicious, and thus is considered "small."
 
 - > nodes should value their local (first-available) segment with preference over the later proposed segment
 
 Valuation is conventionalized as the difference between treating a block as a canonical head versus treating it like a side chain. In both cases the block data is stored and may be propagated. Miners normally only mine on top of blocks they consider to be canonical.
 
-
 <img src="https://user-images.githubusercontent.com/45600330/93938960-aee75180-fcef-11ea-83bb-3f0c57df5abf.png" />
-
 
 #### Algorithm details
 
@@ -55,7 +53,7 @@ This specification for subjective arbitration of chain segments based on availab
 
 This specification falls outside of existing consensus protocol. With that, the need for congruent implementation(s) across protocol providers (_aka_ clients) on the network is important to avoid observable or actionable variances in implementation that might present a risk to network coherence (whether by malicious intention or accident).
 
-This specification should be applied in the client wherever total difficulty is used to evaluate a block's candidacy for the head of the chain database. In etclabscore/core-geth this occurs in the `BlockChain.writeBlockWithState` and its caller `BlockChain.insertChain` methods. 
+This specification should be applied in the client wherever total difficulty is used to evaluate a block's candidacy for the head of the chain database. In etclabscore/core-geth this occurs in the `BlockChain.writeBlockWithState` and its caller `BlockChain.insertChain` methods.
 
 This specification should be applied only given the condition of a positive outcome for the existing subjective arbitration cases described below.
 
@@ -63,7 +61,8 @@ In the case of a negative result from the arbitration, blocks should be deferred
 
 #### Existing Subjective Arbitrations
 
-This specification assumes __existing__ extra-protocol behavior as:
+This specification assumes **existing** extra-protocol behavior as:
+
 - preference of self-mined blocks for proposed blocks having equal total difficulty and number
 - then, a 50% randomized acceptance rate for proposed blocks having equal total difficulty and number, per [Eyal and Sirer](http://www.cs.cornell.edu/~ie53/publications/btcProcFC.pdf)
 
@@ -89,6 +88,7 @@ These evaluations are implemented at the etclabscore/core-geth and ethereum/go-e
 		}
 	}
 ```
+
 > https://github.com/etclabscore/core-geth/blob/eb8bbb02a5b1516ab181a49117c970270532aa03/core/blockchain.go#L1525, https://github.com/ethereum/go-ethereum/blob/129cf075e963df10f42da81d817a4c12f7d4bf16/core/blockchain.go#L1518
 
 ```go
@@ -146,16 +146,17 @@ func (s *Ethereum) shouldPreserve(block *types.Block) bool {
 	return s.isLocalBlock(block)
 }
 ```
+
 > https://github.com/etclabscore/core-geth/blob/129cf075e963df10f42da81d817a4c12f7d4bf16/eth/backend.go#L379-431, https://github.com/ethereum/go-ethereum/blob/129cf075e963df10f42da81d817a4c12f7d4bf16/eth/backend.go#L359-L411
 
 #### Proposed Additional Subjective Arbitration
 
 As a successor to established chain reorganization arbitration, the following logic should be added.
 
-- A polynomial function `ecbp1100PolynomialV` is defined which implements a cubic curve as the "antigravity" of a proposed chain segment. 
+- A polynomial function `ecbp1100PolynomialV` is defined which implements a cubic curve as the "antigravity" of a proposed chain segment.
 - A condition function `ecbp11100` applies this value as a required total difficulty ratio for proposed chain segments over their local alternative.
 
-__Polynomial `ecbp1100PolynomialV`__
+**Polynomial `ecbp1100PolynomialV`**
 
 ```python
 CURVE_FUNCTION_DENOMINATOR = 128
@@ -169,11 +170,10 @@ def get_curve_function_numerator(time_delta: int) -> int:
     return CURVE_FUNCTION_DENOMINATOR + (3 * x**2 - 2 * x**3 // xcap) * height // xcap ** 2
 
 ```
+
 > Source: https://github.com/ethereumclassic/ECIPs/issues/374#issuecomment-694156719
 
-
-
-__Condition `ecbp1100`__
+**Condition `ecbp1100`**
 
 ```python
 if proposed_subchain_td * CURVE_FUNCTION_DENOMINATOR < get_curve_function_numerator(current.Time - commonAncestor.Time) * local_subchain_td:
@@ -314,6 +314,7 @@ var ecbp1100PolynomialVHeight = new(big.Int).Mul(new(big.Int).Mul(ecbp1100Polyno
 ## Rationale
 
 This is a _modified (M)_ version of Buterin's _Exponential Subjective Scoring (ESS)_ by
+
 - using a capped polynomial function instead of an unbounded exponential function
 - using the difference of local head time(stamp) from common ancestor time(stamp), rather than the previously described block lengths or times of block reception used by Buterin.
 
@@ -329,12 +330,11 @@ The normal functioning of the chain is _explained_ (as in _rationalized_) by som
 
 In consideration here is a proposal of CONVENTION for network participants that is designed to keep the network as unified as possible while describing an opinion (implemented as algorithm) that prevents big ugly late-coming chain segments from being immediately and automatically accepted.
 
-This is functionally no different than a thought experiment where the human miners are watching their nodes day-in and day-out, every minute, arbitrating with their own personal opinions about whether or not to allow geth to mine on top of block `10550798`. Again, _they are allowed to do this._ They can do this. Sometimes they _do_ do this. This proposal is a specification of a way that they can make this same order of decisions, but with the help of some math, a computer, and heuristics that will allow them to do it in coordination without requiring the use of the world's most boring conference call. 
+This is functionally no different than a thought experiment where the human miners are watching their nodes day-in and day-out, every minute, arbitrating with their own personal opinions about whether or not to allow geth to mine on top of block `10550798`. Again, _they are allowed to do this._ They can do this. Sometimes they _do_ do this. This proposal is a specification of a way that they can make this same order of decisions, but with the help of some math, a computer, and heuristics that will allow them to do it in coordination without requiring the use of the world's most boring conference call.
 
+In fact, one of the first evolutions of this proposal was made by @BelfordZ:
 
-In fact, one of the first evolutions of this proposal was made by @BelfordZ: 
-
-> When geth wants to reorganize its existing chain for a too-long or too-old chain segment, have it just send an email to its operator saying: _Geth has found a suspicious chain segment and requires a human's wisdom and advice_... and then turn off. 
+> When geth wants to reorganize its existing chain for a too-long or too-old chain segment, have it just send an email to its operator saying: _Geth has found a suspicious chain segment and requires a human's wisdom and advice_... and then turn off.
 
 Except for a few fancy bells and whistles (_ie_ maybe not shutting down... :)), and a proposed CONVENTION for determining suspicion, these proposals are more alike than different.
 
@@ -354,13 +354,11 @@ The graphs below show a 200 block chain accepting, sidechaining ~~or rejecting~~
 
 ![mess-acceptreject](https://user-images.githubusercontent.com/45600330/93946544-27094380-fcff-11ea-9ad0-bd9526fad286.png)
 
-
 #### Costs
 
 - Nodes subject to eclipse attacks (mostly considered as nodes coming online after a long time or starting out) are vulnerable to destitution, even once released. This is addressed by the function's ceiling causing the attacker to need to establish (and maintain) a total difficulty 1/31x of the competing honest chain, and can be addressed further by the operator including a checkpoint value.
 - It may be anticipated that the network uncle and waste rates will rise slightly, as blocks that would otherwise be [randomly included](http://www.cs.cornell.edu/~ie53/publications/btcProcFC.pdf) will be rejected. ETC currently has a 3.5% uncle rate compared to ETH's 5.5%.
 - A network vulnerability resulting in bifurcation exists given the condition that competing segments become available with near-equal total difficulty within the window of the antigravity curve allowance. This state of balance must be maintained until the antigravities force the network partitions to reject each other's segments. If a state of near-perfect balance in total difficulty between the partitions can be maintained, this bifurcated state shall be indefinite. _However_, achieving and maintaining a balanced competition between segments can be seen to be extraordinarily challenging, expensive, and ultimately unlikely. Confounding variables for an attacker in this scenario are normal network hashrate variability, network propagation times and protocol, disproportionate mining entity hashpower share, unpredictable block times, and existing subjective arbitration steps.
-
 
 #### Discussion of Constant Parameters
 
@@ -368,14 +366,14 @@ The polynomial function uses constant parameters `xcap = 2pi/8000` and `amplitud
 
 The _x cap_ value of `2pi/8000` causes the peak of the curve (and ultimate ceiling) to occur at 25132 seconds (approximately 7 hours). This falls in between the rates of the previously considered exponential functions. The "ramp up" domain (nearest `x=0`) sees a flattened curve, yielding a more generous lenience for competing short segments. The curve eventually intersects the original exponential function at about 900 seconds (15 minutes) at about `y=1.09`.
 
-The _amplitude_ value of `15` causes the peak to occur at `(2*15)+1 = 31`. This value means that the maximum "antigravity" an attack will face is a 31, where the proposed chain would need a total difficulty 31 times that of the chain it would replace. 
+The _amplitude_ value of `15` causes the peak to occur at `(2*15)+1 = 31`. This value means that the maximum "antigravity" an attack will face is a 31, where the proposed chain would need a total difficulty 31 times that of the chain it would replace.
 
 These values were chosen for ETC with the following assumptions and reasoning.
 
 - Assume global Ethash hashrate availability is 200TH.
 - Assume greatest single Ethash mining _entity_ is 33% of the global, yielding about 66TH. This is considered as the largest possible antagonist for the ETC chain.
 - Assume ETC has 3TH total contributed hashrate.
-- Following this, we deduce that the largest Ethash mining entity has 22 times of ETC's current mining power. An "attack" by this entity on ETC would result in a `(66/(66+3))*100 = 95`% attack. 
+- Following this, we deduce that the largest Ethash mining entity has 22 times of ETC's current mining power. An "attack" by this entity on ETC would result in a `(66/(66+3))*100 = 95`% attack.
 - Given a 22x anticipated "reasonable" worst-case scenario, the amplitude of `15` yielding a total `31` ceiling, around 50% above the anticipated worst-case scenario, is intended to be sufficiently future-proof and resilient to unforeseen scenarios.
 
 #### Alternatives Considered
@@ -386,21 +384,21 @@ An bounded exponential function would work in much the same way, although it wou
 
 This feature does not require a hard fork, but the network stands to benefit and avoid risk with majority coordinated acivation.
 
-__Core-Geth__
+**Core-Geth**
 
 - Feature is tentatively proposed to activate in Core-Geth on Ethereum Classic network at and above block 11_380_000 (ETA 09 October 2020).
 - Feature is proposed to activate in Core-Geth on Ethereum Classic's Mordor test network at and above block 2380000 (ETA 29 September 2020).
 - Core-Geth feature implementation includes a few additional safety mechanisms:
-  + MESS is disabled for any sync mode besides full sync.
-  + MESS is only enabled once a peer has completed initial chain synchronisation, not while they are fast syncing or even full syncing during the download and process phase. This reduces the chances of a node coming online being lured into an eclipse scenario.
-  + MESS is only enabled if a peer has greater than or equal to the `MinimumSyncPeers` peers. In Core-Geth this value is by default `5`.
-  + MESS is disabled if, once synced, a node's head block is not changed within a time limit (ie becomes stale).  In Core-Geth this value is by default `30 * 13 seconds`.
-  
+  - MESS is disabled for any sync mode besides full sync.
+  - MESS is only enabled once a peer has completed initial chain synchronisation, not while they are fast syncing or even full syncing during the download and process phase. This reduces the chances of a node coming online being lured into an eclipse scenario.
+  - MESS is only enabled if a peer has greater than or equal to the `MinimumSyncPeers` peers. In Core-Geth this value is by default `5`.
+  - MESS is disabled if, once synced, a node's head block is not changed within a time limit (ie becomes stale). In Core-Geth this value is by default `30 * 13 seconds`.
+
 The associated Core-Geth implementation is available [here](https://github.com/etclabscore/core-geth/pull/181).
 
 ### Testing
 
-Cross client tests are included [as assets](../assets/ecbp-1100/testdata) as "first" and "second" RLP-encoded chain segments. A [genesis configuration](../assets/ecbp-1100/testdata) is provided describing the necessary chain and genesis configuration. 
+Cross client tests are included [as assets](../assets/ecbp-1100/testdata) as "first" and "second" RLP-encoded chain segments. A [genesis configuration](../assets/ecbp-1100/testdata) is provided describing the necessary chain and genesis configuration.
 
 The file names describe the test, as well as providing expectations for the outcome of the second chain import via the suffix `secondWins-true` vs. `secondWins-false`.
 
@@ -410,7 +408,6 @@ The file names describe the test, as well as providing expectations for the outc
 - https://blog.ethereum.org/2014/11/25/proof-stake-learned-love-weak-subjectivity/
 
 Bespoke previously considered exponential functions:
-
 
 ```go
 /*

--- a/_specs/ecip-1100.md
+++ b/_specs/ecip-1100.md
@@ -4,7 +4,7 @@ title: MESS (Modified Exponential Subjective Scoring)
 lang: en
 author: Isaac <b5c6@protonmail.com>
 discussions-to: https://github.com/ethereumclassic/ECIPs/issues/374
-status: Replaced
+status: Active
 type: Standards Track
 category: ECBP
 created: 2020-09-09
@@ -15,7 +15,7 @@ license: Apache-2
 
 Define a function arbitrating chain acceptance using relative total difficulty and common ancestor time to raise finality confidence.
 
-_Update (January 2024):_ [ECBP-1110](https://ecips.ethereumclassic.org/ECIPs/ecip-1110) turned the bundled default off. The mechanism remains in the client and available to any operator who enables it.
+_Update (January 2024):_ [ECBP-1110](https://ecips.ethereumclassic.org/ECIPs/ecip-1110) recommends client developers set ECBP-1100 to disabled by default. The MESS mechanism remains in the client and available to any operator who enables it, so ECBP-1100 remains active and optional.
 
 ## Motivation
 

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -13,7 +13,7 @@ license: Apache-2
 
 ## Abstract
 
-Turn off the artificial finality mechanism [ECBP-1100's MESS (Modified Exponential Scoring)](https://ecips.ethereumclassic.org/ECIPs/ecip-1100) in [Core-Geth](https://github.com/etclabscore/core-geth) for Ethereum Classic.
+Turn the default flag to off in the client for the artificial finality mechanism [ECBP-1100's MESS (Modified Exponential Scoring)](https://ecips.ethereumclassic.org/ECIPs/ecip-1100) in [Core-Geth](https://github.com/etclabscore/core-geth) for Ethereum Classic.
 
 ## Motivation
 
@@ -33,7 +33,7 @@ Users will be encouraged to upgrade to Core-Geth v1.12.17, or to deactivate MESS
 
 ### Mordor (ETC PoW Testnet)
 
-MESS will be deactivated at block `10,400,000`.
+MESS will be deactivated by default at block `10,400,000`.
 
 ## Rationale
 

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -1,6 +1,6 @@
 ---
 ecip: 1110
-title: Deactivate MESS (Modified Exponential Subjective Scoring)
+title: Disable MESS (Modified Exponential Subjective Scoring) as Default
 lang: en
 author: Isaac <isaac@etccooperative.org>
 discussions-to: https://github.com/orgs/ethereumclassic/discussions/522
@@ -13,7 +13,7 @@ license: Apache-2
 
 ## Abstract
 
-Turn the default flag to off in the client for the artificial finality mechanism [ECBP-1100's MESS (Modified Exponential Scoring)](https://ecips.ethereumclassic.org/ECIPs/ecip-1100) in [Core-Geth](https://github.com/etclabscore/core-geth) for Ethereum Classic.
+Due to a surge of hashrate in 2023, this ECBP is a recommendation to turn the default MESS flag to off in the client for the artificial finality mechanism [ECBP-1100's MESS (Modified Exponential Scoring)](https://ecips.ethereumclassic.org/ECIPs/ecip-1100). The MESS mechanism remains in the client and available to any operator who enables it.
 
 ## Motivation
 

--- a/_specs/ecip-1110.md
+++ b/_specs/ecip-1110.md
@@ -25,15 +25,15 @@ The costs of persisting any kind of subjective chain arbitration on the network 
 
 ## Specification
 
-MESS will be deactivated by default at block `19,250,000`. This is concurrent with [ECIP-1109's Spiral Hardfork](https://ecips.ethereumclassic.org/ECIPs/ecip-1109).
+MESS will be disabled by default at block `19,250,000`. This is concurrent with [ECIP-1109's Spiral Hardfork](https://ecips.ethereumclassic.org/ECIPs/ecip-1109).
 
-An override flag for this decision will be provided to configure ongoing operation `--override.ecbp1100-deactivate=<number>`.
+An override flag for this decision will be provided to configure ongoing operation `--override.ecbp1100.deactivate=<number>`.
 
-Users will be encouraged to upgrade to Core-Geth v1.12.17, or to deactivate MESS manually, which can be done with all versions of core-geth implementing MESS using the flag value: `--ecbp1100=99999999999` or equivalent.
+Users will be encouraged to upgrade to Core-Geth v1.12.17, or to disable MESS manually, which can be done with all versions of core-geth implementing MESS using the flag value: `--ecbp1100=99999999999` or equivalent.
 
 ### Mordor (ETC PoW Testnet)
 
-MESS will be deactivated by default at block `10,400,000`.
+MESS will be disabled by default at block `10,400,000`.
 
 ## Rationale
 


### PR DESCRIPTION
ECBP-1100 is marked `Replaced` and ECBP-1110 is titled "Deactivate MESS". Both misstate where the network actually stands: MESS is still present in Core-Geth and any operator can enable it. ECBP-1110 recommended that client developers ship the flag off by default — it did not remove the mechanism, and nothing replaced ECBP-1100.

>Abstract
>Turn off the artificial finality mechanism [ECBP-1100’s MESS (Modified Exponential Scoring)](https://ecips.ethereumclassic.org/ECIPs/ecip-1100) in [Core-Geth](https://github.com/etclabscore/core-geth) for Ethereum Classic.

### ecip-1100

- `status: Replaced` → `status: Active`. Nothing replaced it, and the mechanism is still in the client.
- The January 2024 update note read "Replaced with ECBP-1110". It now states that ECBP-1110 recommends the disabled default, that MESS remains available to any operator who enables it, and that ECBP-1100 therefore remains active and optional.

### ecip-1110

- Retitled "Deactivate MESS (Modified Exponential Subjective Scoring)" → "Disable MESS (Modified Exponential Subjective Scoring) as Default", so the title states what the ECBP recommends rather than confusing it with removal.
- The abstract now names the 2023 hashrate surge as the reason for the recommendation, and states that the mechanism remains available to any operator who enables it.
- "Deactivated" → "disabled" in the Specification and Mordor sections, so the document uses one verb throughout for one thing. The Mordor line also gains "by default", matching the mainnet line above it.

### Override flag name

The Specification documented the override flag as `--override.ecbp1100-deactivate`. Core-Geth v1.12.17 — the release this ECBP names — spells it with a dot:

```go
// cmd/utils/flags.go, v1.12.17
OverrideECBP1100DeactivateFlag = &cli.Uint64Flag{
	Name:     "override.ecbp1100.deactivate",
	Usage:    "Manually specify the ECBP-1100 (MESS) deactivation block number, overriding the bundled setting",
	Category: flags.EthCategory,
}
```

The hyphenated form appears nowhere in that release, so an operator copying it out of this document gets an unknown-flag error. Corrected to `--override.ecbp1100.deactivate`.

`--ecbp1100=99999999999` further down is left as written — it is the activation flag's real name at that release.

### Non-substantive

`ecip-1100` also picks up markdown normalization: `__bold__` → `**bold**`, `+` list markers → `-`, trailing whitespace removed, and blank lines inserted before some lists and block quotes. No wording changes, and no change to rendered output — the affected lists and quotes already rendered correctly.
