### PR TITLE
fix(build): wrap Go test-case blocks in raw tags so Liquid stops dropping them

### DIFF
--- a/_specs/ecip-1048.md
+++ b/_specs/ecip-1048.md
@@ -190,6 +190,7 @@ This list may be expired after a certain number of blocks / epochs, but it's imp
 
 ## Test Cases
 
+{% raw %}
 ```go
 // block represents a single block signed by a parcitular account, where
 // the account may or may not have cast a Clique vote.
@@ -466,6 +467,7 @@ tests := []struct {
   },,
 }
 ```
+{% endraw %}
 
 ## Implementation
 

--- a/_specs/ecip-1060.md
+++ b/_specs/ecip-1060.md
@@ -128,6 +128,7 @@ Finally, without changing any consensus logic, we propose the ability to specify
 
 ## Test Cases
 
+{% raw %}
 ```go
 // block represents a single block signed by a particular account, where
 // the account may or may not have cast a Clique vote.
@@ -404,6 +405,7 @@ tests := []struct {
   },,
 }
 ```
+{% endraw %}
 
 ## Implementation
 


### PR DESCRIPTION
`_specs/ecip-1048.md` and `_specs/ecip-1060.md` each contain the Go composite literal `[]block{{signer: "A"}}` in their Test Cases block.

Jekyll runs Liquid before Markdown, so the code fence does not protect it. Liquid parses `{{signer: "A"}}` as an output tag, fails, and emits nothing — the line is dropped from the built site.

| | |
|---|---|
| Source | `blocks:  []block{{signer: "A"}},` |
| Published page | `blocks:  []block,` |

The build also logs two warnings:

```
Liquid Warning: Liquid syntax error (line 201): Expected end_of_string but found colon in "{{signer: "A"}}" in _specs/ecip-1048.md
Liquid Warning: Liquid syntax error (line 138): Expected end_of_string but found colon in "{{signer: "A"}}" in _specs/ecip-1060.md
```

Wrapping each Test Cases block in `{% raw %}` / `{% endraw %}` fixes it. No specification text is changed.

Verified with `bundle exec jekyll build --future`:

- Liquid warnings: **2 → 0**
- Both lines now render exactly as the source writes them
- Across the whole build only these two pages change, by that one line each (`feed.xml` differs only by its build timestamp)
