### PR TITLE
fix(site): sort ECIP tables by `ecip` not the non-existent `ecip-`

### DIFF
--- a/_includes/eiptable.html
+++ b/_includes/eiptable.html
@@ -8,7 +8,7 @@
   }
 </style>
 {% for status in site.data.statuses %}
-  {% assign eips = include.eips|where:"status",status|sort:"ecip-" %}
+  {% assign eips = include.eips|where:"status",status|sort:"ecip" %}
   {% assign count = eips|size %}
   {% if count > 0 %}
     <h2>{{status}}</h2>


### PR DESCRIPTION
`_includes/eiptable.html` sorts each status table with `sort:"ecip-"`. The front-matter field is `ecip` — nothing has an `ecip-` property, so the filter is a no-op and the tables fall back to Jekyll's default collection order, which is path order.

That happens to look correct for the top-level specs, whose filenames sort the same way as their numbers. It breaks for the one nested file, `_specs/zh/ecip-1017.md`, in the **Final** table:

| | order |
|---|---|
| before | 1010, 1015, 1017, 1039, … 1104, 1109, **1017 (zh)** |
| after | 1010, 1015, 1017, **1017 (zh)**, 1039, … 1104, 1109 |

Verified with `bundle exec jekyll build --future` across all seven pages that use the include:

| page | tables | rows before | rows after |
|---|---|---|---|
| all | 7 | 97 | 97 |
| core | 5 | 43 | 43 |
| ecbp | 4 | 13 | 13 |
| interface | 2 | 7 | 7 |
| meta | 6 | 26 | 26 |
| networking | 2 | 2 | 2 |
| informational | 2 | 4 | 4 |

Every status table is now in ascending ECIP order, and row counts are unchanged — nothing dropped or duplicated.
