### PR TITLE
spec(ecip-1111): update to post implementation draft

### DIFF
--- a/_specs/ecip-1111.md
+++ b/_specs/ecip-1111.md
@@ -199,7 +199,7 @@ Activation blocks are to be finalized through open coordination among client imp
 - **Mordor Testnet**: `TBD`
 - **ETC Mainnet**: `TBD`
 
-**These blocks are recorded here and in no other document.**
+**This ECIP is the only document in which these blocks are recorded.**
 
 **Cross-client agreement is evidence that this specification is unambiguous only where the implementations do not share a state-transition codebase.** Before this ECIP advances to `Final`, the vectors above MUST be executed on at least two implementations whose state-transition code derives from unrelated upstreams, and both the vectors and their results MUST be published as data a third party can re-execute.
 

--- a/_specs/ecip-1111.md
+++ b/_specs/ecip-1111.md
@@ -1,11 +1,10 @@
 ---
 lang: en
 ecip: 1111
-title: Olympia EVM and Protocol Upgrades
+title: Base Fee Market and Redirection
 status: Draft
 type: Standards Track
 category: Core
-requires: 1112
 author: Cody Burns (@realcodywburns), Chris Mercer (@chris-mercer)
 created: 2025-07-04
 discussions-to: https://github.com/orgs/ethereumclassic/discussions/530
@@ -14,476 +13,223 @@ license: CC0-1.0
 
 ### Simple Summary
 
-This proposal introduces EIP-1559 and EIP-3198 to Ethereum Classic via a hard fork named **Olympia**. These upgrades enhance EVM compatibility and modernize gas pricing mechanics. Unlike Ethereum Mainnet, where the `BASEFEE` is burned, Ethereum Classic redirects it to the **Olympia Treasury** (ECIP-1112) — an immutable, governance-isolated on-chain funding contract.
-
-This establishes a transparent, non-inflationary protocol-level funding source while preserving Proof-of-Work consensus and Ethereum Classic’s principles of immutability, neutrality, and decentralization.
-
-Until governance defined in ECIP-1113 and ECIP-1114 is activated, the Treasury accumulates funds passively with no disbursements, ensuring secure and trustless value storage.
+Activates EIP-1559 and EIP-3198 on Ethereum Classic. Where Ethereum Mainnet destroys the base fee, Ethereum Classic credits it at the consensus layer to a permanent address held in chain configuration, changeable only by a further hard fork. Miner block rewards and priority-fee tips are unaffected.
 
 ### Abstract
 
-This ECIP proposes the activation of select Ethereum protocol upgrades on Ethereum Classic under the hard fork name **Olympia**. Specifically, it introduces:
+This ECIP activates two Ethereum protocol upgrades on Ethereum Classic:
 
-- **EIP-1559**: Implements a dynamic `basefee` adjustment mechanism to improve fee predictability and market efficiency.
-- **EIP-3198**: Adds the `BASEFEE` opcode for full EVM opcode compatibility.
+- **EIP-1559** — dynamic base-fee adjustment.
+- **EIP-3198** — the `BASEFEE` opcode, for EVM opcode compatibility.
 
-These changes improve interoperability with Ethereum and other EVM-based networks while preserving Ethereum Classic’s Proof-of-Work consensus and principles of immutability.
-
-All `BASEFEE` revenue is redirected to the **Olympia Treasury** (ECIP-1112), a deterministic, immutable contract defined at the protocol level. Governance and funding flows for this Treasury are specified separately in **ECIP-1113** (Olympia DAO Governance Framework) and **ECIP-1114** (Ethereum Classic Funding Proposal Process).
-
-This upgrade explicitly excludes changes related to Ethereum’s Proof-of-Stake transition, including validator operations and beacon-chain-based randomness, which are not applicable to Ethereum Classic. Implementation requires coordinated deployment across client software and node operators, with block heights to be finalized for both **Mordor Testnet** and **Mainnet** activation.
-
-### EIP Summaries and Expected Action
-
-#### Included in the Olympia Upgrade
-
-- **EIP-1559 – Fee Market Change**  
-  Introduces a new transaction type with a dynamically adjusting `basefee` based on block gas usage and an optional miner tip (`priorityFee`).  
-  On Ethereum Classic, unlike Ethereum Mainnet, the `basefee` is **not burned**. It is redirected at the consensus layer to the deterministic **Olympia Treasury** address defined in ECIP-1112. Miner tips (`priorityFee`) remain payable directly to block producers.
-
-- **EIP-3198 – `BASEFEE` Opcode**  
-  Adds opcode `0x48` (`BASEFEE`), returning the current block’s `basefee`.  
-  This enables fee-aware contract logic, improved gas estimation, and standard EVM opcode compatibility.
-
-This ECIP proposes activation of both EIPs at the following block heights (to be finalized after successful testnet deployment):
-
-- **Mordor Testnet**: `TBD`  
-- **Ethereum Classic Mainnet**: `TBD`  
-  _(See Activation section for final coordination and release details.)_
-
-For technical implementation details, see the **Specification** section below.
+The base fee charged to each transaction is credited to the `SOVEREIGNTY_VAULT` address rather than destroyed. A permanent minimum base fee is applied at every block. **This ECIP defines the consensus-layer rule and nothing above it**: what is deployed at that address, and how the balance held there is governed and spent, are outside its scope and do not affect its correctness.
 
 ### Motivation
 
-The Olympia upgrade enhances Ethereum Classic’s protocol by integrating widely adopted Ethereum Virtual Machine (EVM) features — specifically EIP-1559 and EIP-3198. These changes bring Ethereum Classic into closer alignment with the modern EVM ecosystem, improving interoperability, developer experience, and long-term maintainability.
+EIP-1559 and EIP-3198 are standard across the EVM ecosystem, and adopting them gives contracts fee-aware logic through the `BASEFEE` opcode.
 
-EIP-1559 and EIP-3198 provide several benefits:
+**Modern EVM tooling assumes EIP-1559.** Foundry sends a Type-2 transaction to any chain absent from its legacy registry, Ethereum Classic among them, while libraries that probe the chain fall back correctly — so support here rests on a code path each integrator maintains for this network alone, and activating EIP-1559 and EIP-3198 removes that path rather than documenting it.
 
-1. **Improved EVM Compatibility**  
-   Adoption of EIP-1559 and the `BASEFEE` opcode enables Ethereum Classic to support transaction formats and gas-pricing conventions now standard across most EVM networks. This reduces friction for developers and tooling providers and improves cross-chain portability.
+**Crediting the base fee rather than destroying it converts a flow EIP-1559 charges anyway into a funding source the network raises from its own use.** It accrues without a foundation, a donor, or a grant, and reduces no miner compensation, and a permanent floor keeps it from falling to zero when blocks are empty — which on Ethereum Classic they usually are. The network has had no such source, its execution layer trails four Ethereum upgrades, and [ECIP-1017](https://ecips.ethereumclassic.org/ECIPs/ecip-1017)'s emission schedule declines on a fixed timetable regardless.
 
-2. **Modernized Fee Market**  
-   EIP-1559 introduces a dynamic `basefee` mechanism that provides more predictable gas pricing and a clearer distinction between network congestion pricing and miner incentives. This results in more consistent application and user behavior across EVM chains.
-
-3. **Expanded Tooling and Infrastructure Support**  
-   Parity with widely supported EVM standards improves compatibility with wallets, infrastructure services, and development frameworks that increasingly assume EIP-1559 semantics.
-
-4. **Sustainable Protocol-Level Funding**  
-   Redirecting the `BASEFEE` to the Olympia Treasury (ECIP-1112) creates a transparent, non-inflationary source of protocol revenue. This supports long-term client maintenance, infrastructure reliability, and ecosystem security as block rewards decline under [ECIP-1017](https://ecips.ethereumclassic.org/ECIPs/ecip-1017).
-
-While EIP-1559 originated on Ethereum, its inclusion here remains consistent with Ethereum Classic’s principles of immutability and censorship resistance. It modifies no historical state, introduces only additive transaction formats, and does not require trust in off-chain actors.
+Activating EIP-1559 is consistent with Ethereum Classic's immutability and censorship-resistance principles: it reinterprets no historical block, and requires no trust in any off-chain actor.
 
 ### Specification
 
-The Olympia upgrade activates the following Ethereum protocol improvements on Ethereum Classic. All specifications are implemented exactly as defined in the canonical Ethereum Improvement Proposals (EIPs), except where noted for consensus-layer `BASEFEE` redirection.
+All EIPs below are implemented exactly as canonically defined, except where noted for the consensus-layer base-fee credit.
 
-#### Protocol Changes Adopted from Ethereum's London Hard Fork
+#### Protocol Changes (from Ethereum's London Hard Fork)
 
-- [**EIP-1559 – Fee Market Change**](https://eips.ethereum.org/EIPS/eip-1559)  
-  Introduces a new transaction format with a dynamically adjusting `basefee` based on block gas usage and an optional miner tip (`priorityFee`).  
-  On Ethereum Classic, the `basefee` is **not burned**. Instead, it is redirected at the consensus layer to the deterministic **Olympia Treasury** address defined in ECIP-1112. Miner tips (`priorityFee`) continue to be paid directly to block producers.
+- [**EIP-1559**](https://eips.ethereum.org/EIPS/eip-1559) — new transaction format with a dynamically adjusting base fee and optional miner tip (`priorityFee`). On Ethereum Classic the base fee is **not destroyed** — it is credited at the consensus layer to the `SOVEREIGNTY_VAULT` address. Miner tips continue to be paid directly to miners, unchanged.
+- [**EIP-3198**](https://eips.ethereum.org/EIPS/eip-3198) — opcode `0x48` (`BASEFEE`), giving contracts access to the current block's base fee.
 
-- [**EIP-3198 – `BASEFEE` Opcode**](https://eips.ethereum.org/EIPS/eip-3198)  
-  Adds opcode `0x48` (`BASEFEE`), allowing smart contracts to access the current block’s `basefee`.  
-  This enables fee-aware smart contract logic, improved gas estimation, and consistent EVM behavior across supported tooling.
+No other EVM changes, consensus rules, or opcodes are introduced.
 
-##### Example: Consensus-Layer BASEFEE Redirection
+##### Consensus-Layer Redirection
 
-```go
-// --- BEGIN PSEUDOCODE ---
-// Illustrative example of consensus-layer handling of BASEFEE.
-// This demonstrates redirection of the BASEFEE amount to the
-// Olympia Treasury instead of burning it.
+EIP-1559 charges every transaction a base fee and destroys it. This ECIP credits that amount to a fixed address instead, and changes nothing else about the fee mechanism.
 
-func finalizeBlock(block, state) {
-    // Calculate total BASEFEE from gas used in all transactions
-    baseFeeAmount = block.gasUsed * block.baseFee
+The credit is made **within the transaction's own state transition**, at the point in EIP-1559's block-validation pseudocode where the base fee is otherwise destroyed — immediately after the miner is credited its priority fee, and after the signer has been refunded for unused gas:
 
-    // Redirect BASEFEE to the fixed Treasury address
-    state.addBalance(treasuryAddress, baseFeeAmount)
+```python
+# Unchanged from EIP-1559: the miner only receives the priority fee.
+self.account(block.author).balance += gas_used * priority_fee_per_gas
 
-    // Miner receives priority fees (tips)
-    state.addBalance(block.miner, block.totalPriorityFees)
-
-    return
-}
-// --- END PSEUDOCODE ---
+# EIP-1559 destroys the remainder at this point. This ECIP credits it instead.
+self.account(SOVEREIGNTY_VAULT).balance += gas_used * block.base_fee_per_gas
 ```
 
-##### Pseudocode Notes
+**The second line is the whole of the change**, including EIP-1559's own base-fee adjustment arithmetic, which is unchanged.
 
-- This example is illustrative only; actual implementations appear within each client’s consensus and state-transition logic.
-- `state` represents the client’s execution ledger for applying balance changes during block processing.
-- This behavior is consensus-critical and MUST be implemented identically across any participating Ethereum Classic clients.
+**The credit is per transaction. Implementations MUST NOT compute it as a single block-level product at finalization**, and MUST NOT do both. `block.gasUsed × block.baseFeePerGas` yields the same total for the block, so the two rules agree on the state root at a block boundary and disagree everywhere inside one: under this ECIP, transaction _N+1_ observes a Vault balance that already carries the base fees of transactions _1..N_ of the same block, and that balance is readable by `BALANCE` and `SELFBALANCE`.
 
-🔒 **Consensus-critical logic**: `BASEFEE` redirection is enforced during block finalization and **cannot be bypassed or altered** without a hard fork. The Treasury transfer occurs before miner rewards are applied.
+**The amount credited MUST equal the base fee charged to the sender for that transaction**, computed on the same gas quantity that transaction contributes to `block.gasUsed`.
 
-No additional EVM changes, consensus rules, or opcodes are introduced in this upgrade.
+**Every transaction included in a block pays the base fee on the gas it consumes, and every such payment is credited.** A transaction that reverts still consumes gas, still pays the base fee, and its credit MUST occur.
 
-#### Implementation Notes
+**The credit MUST be a direct addition to the account's balance, and MUST NOT be implemented as a call to the destination.** No EVM code executes: no fallback or `receive` function body runs, no log is emitted, no gas is consumed, and the receiving account can neither observe nor refuse the credit. The destination may hold a contract with a payable fallback, so a credit performed as a call would enter that code, consume gas, and create a failure path where none may exist.
 
-- Clients MUST implement EIP-1559 and EIP-3198 exactly as specified, with the modification that the `basefee` amount is redirected to the Treasury address defined in ECIP-1112 rather than burned.
-- Test vectors MUST be updated to reflect Treasury accumulation instead of `basefee` destruction.
-- Activation SHALL occur at predefined block heights on Mordor Testnet and Ethereum Classic Mainnet (see Activation section).
+##### The Destination Address
 
-Clients and infrastructure providers MUST validate implementation using cross-client consensus tests, including `basefee` calculation, transaction-type handling, and correct Treasury accumulation.
+`SOVEREIGNTY_VAULT` is a chain-configuration parameter holding one address per network, carried in the chain specification each participating client ships — the same configuration surface §Rationale shows Nethermind and Erigon already exposing for this purpose. Changing it therefore costs a coordinated client release, and no on-chain party can change it at all. [ECIP-1112](https://ecips.ethereumclassic.org/ECIPs/ecip-1112) specifies what is deployed at it and how its value is published.
 
-#### Monetary Policy Consideration
+##### Base Fee Constants and the Minimum Base Fee Floor
 
-Redirecting the `BASEFEE` to the Olympia Treasury replaces Ethereum Mainnet’s burn mechanism with protocol-level treasury accumulation, without altering ETC’s total supply or issuance schedule. Monetary policy defined in ECIP-1017 remains unchanged. This change preserves Ethereum Classic’s fixed monetary policy while enabling sustainable, transparent funding for ecosystem maintenance and public infrastructure.
+Two constants govern the base fee, and they are **distinct values that MUST be declared separately in client configuration**:
+
+| Constant           | Value                      | Role                                                                      |
+| ------------------ | -------------------------- | ------------------------------------------------------------------------- |
+| `INITIAL_BASE_FEE` | 1,000,000,000 wei (1 gwei) | EIP-1559's one-shot value, used for the base fee of the fork block itself |
+| `MIN_BASE_FEE`     | 1,000,000,000 wei (1 gwei) | a permanent floor, applied to the result at **every** block               |
+
+**They share a value here and are not the same constant.** Deriving one from the other, or expressing one in terms of the other, is a conflation this ECIP forbids.
+
+```
+baseFeePerGas = max(eip1559BaseFee(parent), MIN_BASE_FEE)
+```
+
+Both constants are carried in chain configuration.
+
+`eip1559BaseFee(parent)` is EIP-1559's `expected_base_fee_per_gas`, computed exactly as that EIP specifies. This ECIP changes the destination of the base fee and clamps its value; it changes **nothing** about the adjustment arithmetic. The clamp interacts with that arithmetic, and the interaction admits two errors that leave a client correct on this chain and wrong elsewhere:
+
+| Parent block                                | Result before the clamp                                                                       |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Fork block (parent precedes the transition) | `INITIAL_BASE_FEE`                                                                            |
+| `gasUsed == gasTarget`                      | parent's `baseFeePerGas`, unchanged                                                           |
+| `gasUsed > gasTarget`                       | parent + `max(parentBaseFee × gasUsedDelta ÷ gasTarget ÷ BASE_FEE_MAX_CHANGE_DENOMINATOR, 1)` |
+| `gasUsed < gasTarget`                       | parent − `parentBaseFee × gasUsedDelta ÷ gasTarget ÷ BASE_FEE_MAX_CHANGE_DENOMINATOR`         |
+
+**The `max(…, 1)` applies to the increase delta only.** EIP-1559 places no floor on the _decrease_ delta, and an implementation MUST NOT add one: doing so over-decrements small base fees relative to EIP-1559. The error is unobservable on any chain whose `MIN_BASE_FEE` exceeds the value at which the decrease delta truncates to zero — which is every chain conforming to this ECIP — so an implementation that shares this code path with an unfloored network is correct here and forks there.
+
+**The clamp MUST be applied to the result on every path above, including the fork block.** Applying it only on the decreasing path yields correct results _solely_ while `MIN_BASE_FEE == INITIAL_BASE_FEE`: the other paths are non-decreasing from the parent, so the floor survives by induction from a base case the fork block supplies. That equality is a coincidence of the values chosen here, not a property of the design, and an implementation relying on it produces sub-floor base fees for any other pairing.
+
+**The clamp MUST be applied in both block production and block validation**, so that a produced block and a validated block cannot disagree, and a block whose `baseFeePerGas` differs from the value this section specifies MUST be rejected — exactly as EIP-1559 already requires for its own computation.
 
 ### Rationale
 
-#### Simplicity by Design
+**Credit, not destroy — and the mechanism is a shipped client feature rather than a modification.** Redirecting the EIP-1559 base fee to an address held in chain configuration is implemented generically by more than one independent Ethereum client, and is active on the production networks tabulated below. Nethermind exposes it as the chain-specification parameters `feeCollector` and `eip1559FeeCollectorTransition`; Erigon exposes it as `burntContract`, a map from activation block to destination address. Neither is a fork or a patch: both are ordinary configuration surfaces that any chain those clients serve may set.
 
-The Olympia upgrade introduces **no additional consensus-layer complexity** beyond the well-established specifications of EIP-1559 and EIP-3198, both of which have been extensively tested and adopted across the EVM ecosystem.
+| Network                               | Destination held in chain configuration                                                          | Active from                        |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| Gnosis (and its Chiado testnet)       | `0x6BBe78ee9e474842Dbd4AB4987b3CeFE88426A92`                                                     | block 19,040,000                   |
+| Polygon PoS (and its Amoy testnet)    | `0x70bcA57F4579f58670aB2d18Ef16e02C17553C38`, later `0x7A8ed27F4C30512326878652d20fC85727401854` | block 23,850,000, later 50,523,000 |
+| Taiko Alethia (and its Hoodi testnet) | `0x1670000000000000000000000000000000010001`                                                     | genesis                            |
+| POA Core                              | `0x517F3AcfF3aFC2fb45e574718bca6F919b798e10`                                                     | block 24,090,200                   |
+| Ronin, in its Layer 1 era             | `0xb903E3936d3ca90b69b29F1df2810083a2DC0d71`                                                     | block 43,447,600                   |
 
-Olympia’s architecture is **modular by intent**:
-- [ECIP-1112](https://ecips.ethereumclassic.org/ECIPs/ecip-1112) (Treasury), [ECIP-1113](https://ecips.ethereumclassic.org/ECIPs/ecip-1113) (Governance Framework), and [ECIP-1114](https://ecips.ethereumclassic.org/ECIPs/ecip-1114) (Funding Proposal Process) are distinct, independently testable components built atop standard smart contract primitives.
-- Each layer can be activated or upgraded independently, allowing protocol functionality, governance, and funding mechanisms to evolve without coupling changes across the stack.
-- No new token is introduced or distributed as part of this upgrade.
+Linea declares the same transition in its chain specification. **What differs between these networks is policy at the far end, not mechanism**: some destinations forward value onward for destruction, others fund network operations. The consensus rule is the same one this ECIP specifies.
 
-This separation mirrors ECIP-1112’s minimalist vault architecture and ECIP-1113’s modular governance structure, ensuring each layer can be maintained or improved without modifying the others.
+**Holding the destination in chain configuration is what makes it costly to change, and there is a worked precedent for exactly that.** Polygon PIP-24, _"Change EIP-1559 Policy"_, moved that network's base-fee recipient by _"adding a new entry in `burntContract` with the hardfork block number and the new address in Bor's Genesis file"_ — a coordinated client release activating at a scheduled block. That is the property this ECIP relies on: an address in chain configuration cannot be changed by any on-chain party, only by the same instrument that installed it. A destination held instead in a contract could be changed by whoever controls that contract, which would make a consensus parameter mutable by a party outside consensus.
 
-#### Interoperability
+**Enforcing the credit at the consensus layer, rather than at the application layer, guarantees deterministic and identical behavior across all clients.** An application-layer mechanism could not make the same guarantee without trusting a specific contract's correctness at every block.
 
-Maintaining EVM interoperability ensures compatibility with:
-- Cross-chain infrastructure (wallets, bridges, RPC providers)
-- dApp frameworks (e.g., Hardhat, Foundry, Scaffold-ETH)
-- Developer tooling and compilers that increasingly assume EIP-1559-style transactions
+**Per transaction, because that is where EIP-1559 itself puts it.** EIP-1559's block-validation pseudocode destroys the base fee inside its per-transaction loop: the signer is debited the effective gas price, the miner is credited the priority fee, and the difference — the base fee — is destroyed at that point, with the EIP's own comment marking the line. Crediting it there is therefore a one-line change to the mechanism being activated, in the position the mechanism already defines. Computing a block-level total at finalization would be a structurally different rule that happens to agree on totals.
 
-By adopting canonical Ethereum upgrades, Ethereum Classic maintains alignment with widely supported EVM conventions, improving tooling compatibility and reducing friction for developers and infrastructure providers.  
-EIP-1559 and EIP-3198 adoption also fulfills the dependency required for the Olympia Treasury’s `BASEFEE` revenue capture mechanism (ECIP-1112).
+The same placement is what production clients implement. Nethermind, Erigon, and Ronin's Layer 1 client each credit the configured destination inside the per-transaction state transition, immediately after the producer's tip, and each excludes transactions that pay no base fee. Aligning with them means a conforming Ethereum Classic client sets a configuration value on an existing code path rather than adding a finalization hook that no such client has.
 
-#### Immutability
+**A fixed floor preserves EIP-1559's adjustment mechanics above it while guaranteeing a non-zero base to operate from, and it is set at one gwei** — one unit of the denomination in which gas prices are expressed, and the magnitude EIP-1559 itself uses for `INITIAL_BASE_FEE`. At fixed demand, revenue is directly proportional to the floor, so the value is a user-cost decision rather than a revenue-maximizing one.
 
-EIP-1559 and EIP-3198 are **strictly additive** upgrades:
-- No changes are made to existing opcodes, transaction types, or state semantics.
-- Historical contracts behave identically post-fork.
-- No retroactive modification of the ETC ledger occurs.
+**A permanent floor distinct from EIP-1559's one-shot initial value is established practice across independent client frameworks**, and they differ in where the value is held rather than in whether to have one:
 
-This preserves Ethereum Classic’s core principle of **immutability** while enabling forward-compatible improvements.
+| Framework                       | Permanent floor                                                                              | Where the value is held                                              | What can change it                                           |
+| ------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Ronin                           | 1 gwei, declared as `MinimumBaseFee` alongside a separate `InitialBaseFee` of the same value | client constant                                                      | a client release                                             |
+| OP Stack, as configured by Base | 5,000,000 wei (0.005 gwei) on both of its networks                                           | the `SystemConfig` contract, propagated into block header extra data | `setMinBaseFee(uint64)`, restricted to that contract's owner |
+| Avalanche subnet-evm            | a **required, non-nil field** of every chain's fee configuration; 25 gwei by default         | chain fee configuration                                              | the `FeeManager` precompile, under its allow-list admin      |
+| Taiko                           | 5,000,000 wei, clamped during header validation                                              | client constant                                                      | a client release                                             |
 
-#### Standards Compliance
+**Ronin's two-constant declaration is the pattern this ECIP adopts**, and the reason is the same one that decides the destination: two of the four frameworks above hold the floor where a party outside consensus can raise or lower it. Ethereum Classic has no such party, so the value belongs where changing it requires a coordinated client release.
 
-Canonical EIPs such as 1559 and 3198 are now **expected defaults** across most major L1 networks and rollups:
-- Many tools, libraries, and RPC providers assume EIP-1559 support.
-- Without these upgrades, Ethereum Classic risks incompatibility with upstream EVM tooling and reduced developer accessibility.
+**Measured from ETC Mainnet block headers on 2026-08-11**, over blocks 24,950,000 to 25,128,560 at a stride of 180 — 993 headers spanning 28.0 days, read independently from two public RPC endpoints then listed for this network at [chainlist.org](https://chainlist.org/chain/61), which agreed on every sampled header:
 
-Adopting these standards ensures that ETC remains aligned with the broader EVM ecosystem, improving long-term maintainability for both dApp and client developers.
+| Quantity                | Measured                                |
+| ----------------------- | --------------------------------------- |
+| Mean gas used per block | **35,414**                              |
+| Aggregate utilization   | **0.4427 %** against an 8,000,000 limit |
+| Empty blocks            | **76.3 %** (758 of 993)                 |
 
-### Modular Activation
-
-ECIP-1111 introduces consensus-layer `BASEFEE` redirection to an on-chain Treasury but does **not** require immediate activation of downstream governance components — including [ECIP-1113](https://ecips.ethereumclassic.org/ECIPs/ecip-1113) (Olympia DAO Governance Framework) or [ECIP-1114](https://ecips.ethereumclassic.org/ECIPs/ecip-1114) (Ethereum Classic Funding Proposal Process).
-
-Instead, `BASEFEE` is redirected to a passive, immutable, governance-isolated Treasury contract defined in [ECIP-1112](https://ecips.ethereumclassic.org/ECIPs/ecip-1112). This Treasury:
-
-- **Accumulates protocol revenue** without disbursing funds  
-- **Remains immutable and transparent** through on-chain auditability  
-- **Restricts all withdrawals** until governance contracts are activated under separate ECIPs  
-
-This modular approach allows ECIP-1111 to remain a single, isolated consensus change, consistent with ECIP-1000. It enables the network to adopt EIP-1559 and EIP-3198 immediately, without introducing:
-
-- Dependencies on governance readiness  
-- Coordination requirements beyond client activation  
-- Any operational or administrative prerequisites  
-
-Activation of governance control over the Treasury is intentionally specified outside of ECIP-1111. It is defined in:
-
-- [ECIP-1113](https://ecips.ethereumclassic.org/ECIPs/ecip-1113), which establishes the on-chain governance framework  
-- [ECIP-1114](https://ecips.ethereumclassic.org/ECIPs/ecip-1114), which defines the standardized funding proposal process  
-
-This separation ensures that consensus changes, Treasury deployment, and governance activation can proceed independently and safely, each undergoing appropriate testing and review.
-
-### Implementation & Reference Client
-
-#### Testnet Coordination & Implementation Status
-
-At the time of writing, prototype implementations of EIP-1559, EIP-3198, and consensus-layer `BASEFEE` redirection are under active development within the Ethereum Classic client ecosystem.
-
-Specific client names, branches, or release artifacts MAY be documented in this section once reference implementations are publicly announced and tagged by their respective maintainers.
-
-Prior to any Mainnet activation, the Olympia upgrade SHALL be tested on the **Mordor Testnet**. Testnet coordination SHOULD cover at minimum:
-
-- Activation parameters (block height or activation epoch)
-- `basefee` calculation and adjustment behavior under varying gas usage
-- Correct accounting of Treasury balances (ECIP-1112)
-- Handling of Legacy (Type-0), Access List (Type-1), and EIP-1559 (Type-2) transactions
-- Cross-client state-transition equivalence and replay protection
-
-Final activation block numbers for both Mordor and Mainnet SHALL be agreed by client implementers, node operators, and other stakeholders, and SHALL be published in an update to this section and in the relevant client release notes.
-
-#### Client Requirements
-
-All ETC client implementations MUST:
-
-- Implement EIP-1559 `basefee` targeting logic  
-- Support Legacy (Type-0), Access List (Type-1), and EIP-1559 (Type-2) transactions  
-- Implement the `BASEFEE` opcode exactly as defined in EIP-3198  
-- Redirect the `BASEFEE` amount to the deterministic Olympia Treasury address (ECIP-1112)  
-- Enforce replay protection and fork ID behavior around the activation block  
-- Apply state-transition rules identically to other participating clients to maintain consensus
-
-### Testing and Coordination
-
-Validation MUST occur on the **Mordor Testnet** before any Mainnet activation.
-
-Test coverage SHOULD include:
-
-- Transaction lifecycle for Legacy (Type-0), Access List (Type-1), and EIP-1559 (Type-2) transactions  
-- Accurate fee accounting (`BASEFEE` redirection vs miner tips)  
-- Correct Treasury accumulation at the consensus layer  
-- `BASEFEE` opcode behavior under empty, partially full, and full gas blocks  
-- Cross-client consensus testing, including block execution equivalence  
-- Fork ID, chain configuration, and replay protection validation  
-- Optional integration testing with ECIP-1112, and—once deployed—ECIP-1113 and ECIP-1114
-
-Activation block heights for Mordor and Mainnet SHALL be finalized through open coordination among client implementers, node operators, miners, exchanges, and infrastructure providers.
-
-#### Scope of This ECIP
-
-This ECIP strictly introduces:
-
-- Activation of **EIP-1559**  
-- Activation of **EIP-3198**  
-- Consensus-layer **`BASEFEE` redirection** to the Olympia Treasury (ECIP-1112)
-
-All governance, funding, and contract-layer functionality is defined separately in:
-
-- **ECIP-1112** — Treasury Contract  
-- **ECIP-1113** — Governance Framework  
-- **ECIP-1114** — Funding Proposal Process  
-
-These ECIPs are independent of ECIP-1111 and MAY be deployed and activated on separate timelines under the modular rollout model.
-
-### EIP Compatibility Scope
-
-The Olympia upgrade is intentionally limited in scope. It activates only two Ethereum protocol improvements:
-
-- **EIP-1559** — Introduces the dynamic `basefee` mechanism and replaces Ethereum Mainnet’s burn behavior with consensus-layer `BASEFEE` redirection to the immutable Olympia Treasury (ECIP-1112).  
-- **EIP-3198** — Adds the `BASEFEE` opcode (`0x48`), enabling contract-level visibility of the current block’s `basefee`.
-
-These EIPs improve fee-market behavior and EVM interoperability without modifying existing contract semantics or introducing any consensus-layer changes beyond the redirection of `BASEFEE`.
-
-No additional EIPs are activated by this proposal. All other Ethereum Foundation EIPs — spanning from **Tangerine Whistle (2016)** through **Prague–Electra (2025)** — were reviewed only for compatibility context and are listed in the **Appendix: EVM Compatibility Roadmap and Upgrade Candidates** section of this ECIP. Their inclusion in the appendix does not imply adoption; any future EVM upgrades would require separate ECIPs.
-
-### Related Work
-
-#### Precedents for Protocol-Level Fee Redirection
-
-While Ethereum Mainnet burns the `basefee` as part of EIP-1559, several production EVM networks have adopted alternative designs that redirect protocol-level fee revenue to on-chain treasuries or governance-controlled funding systems. These precedents fall into two broad categories:
-
-##### Networks that Redirect EIP-1559 `BASEFEE`
-- **Ronin Network** — Redirects the EIP-1559 `basefee` to a DAO-governed treasury that funds infrastructure, validators, and ecosystem programs.
-
-##### Networks that Redirect Other Forms of Protocol or Sequencer Revenue
-- **Celo** — Redirects gas fees to a governance-managed Gas Fee Handler that allocates funds to community and climate initiatives.
-- **Mantle** — Routes sequencer revenue to a DAO treasury for grants, tooling, and infrastructure.
-- **Polygon CDK** — Allows sovereign rollups to implement EIP-1559-compatible fee hooks for governance-controlled treasuries.
-- **OP Stack** (used by Base, Optimism) — Supports sequencer revenue splitting for public-goods funding.
-- **Arbitrum** — Directs sequencer revenue into a DAO-managed treasury, with allocations governed through the AIP process.
-- **Optimism** — Allocates sequencer revenue to Retroactive Public Goods Funding (RPGF).
-- **zkSync Era & Scroll** — Include revenue hooks that can forward sequencer income to protocol-aligned treasuries.
-- **Avalanche Subnets** — Some subnet configurations route transaction fees to validator-governed treasuries.
-- **Gitcoin DAO** — While not fee-based, it provides a notable example of transparent, governance-directed public goods funding.
-
-These examples demonstrate that redirecting protocol-level fee or revenue flows to transparent, governance-controlled treasuries is an established design pattern across modern EVM systems. Such mechanisms support sustainable funding for core protocol work, infrastructure, and public goods.
-
-In adopting consensus-layer `BASEFEE` redirection, Ethereum Classic implements a non-inflationary, protocol-native funding mechanism that maintains ETC’s fixed monetary policy while enabling transparent and auditable treasury accumulation.
-
-### Future Work (Non-Consensus Extensions)
-
-The scope of ECIP-1111 is intentionally limited to the activation of EIP-1559, EIP-3198, and consensus-layer `BASEFEE` redirection to the Olympia Treasury (ECIP-1112).
-
-Additional miner-alignment or revenue-smoothing mechanisms MAY be proposed in a separate, additive ECIP. A future proposal — tentatively referred to as **ECIP-1115** — may explore optional approaches to modifying how Treasury-bound `BASEFEE` is handled at the application or governance layer.
-
-Any such proposal:
-
-- SHALL be introduced as an independent ECIP  
-- SHALL be strictly **additive** and SHALL NOT modify the consensus rules introduced in ECIP-1111  
-- SHALL undergo full review under the ECIP-1000 process  
-- SHALL require independent testnet validation prior to activation  
-- WOULD remain optional and modular within the broader Olympia framework  
-
-No additional miner-alignment or smoothing mechanics are included in ECIP-1111 to preserve its role as a minimal, isolated consensus change.
+**Revenue scales linearly with gas consumed**, so it grows with adoption without governance action, and while blocks remain largely empty it is bounded by `MIN_BASE_FEE`.
 
 ### Backwards Compatibility
 
-The Olympia upgrade introduces:
+Fully additive: a new transaction type (Type-2) and a new opcode (`BASEFEE`, `0x48`). Type-0 and Type-1 transactions, existing deployed contracts, and historical state are unaffected. Clients that do not implement this ECIP will fork from the canonical chain at the activation block, as with any consensus change.
 
-- A new transaction type: **Type-2 (EIP-1559)**
-- A new EVM opcode: **`BASEFEE` (EIP-3198)**
-- Consensus-layer redirection of the `BASEFEE` amount to the immutable Olympia Treasury (ECIP-1112)
+Monetary policy ([ECIP-1017](https://ecips.ethereumclassic.org/ECIPs/ecip-1017)) is unchanged — this ECIP replaces destruction with accumulation, and alters neither Ethereum Classic's total supply nor its issuance schedule.
 
-All existing functionality remains unchanged:
+### Test Cases
 
-- **Type-0 transactions** continue to be valid and fully supported  
-- **Type-1 (Access List) transactions** introduced by ECIP-1103 remain valid and unchanged  
-- **Previously deployed contracts** operate without modification  
-- **Historical blocks and state** are preserved without retroactive changes
+Cross-client state-transition equivalence MUST be demonstrated on Mordor Testnet before a Mainnet activation block is scheduled. Vectors MUST cover:
 
-The upgrade is **fully additive** — the new transaction format and opcode are optional to use. Legacy (Type-0) and Access List (Type-1) transactions continue to function without modification.
-
-#### Client Upgrade Requirements
-
-- Clients that do not implement the Olympia upgrade will diverge from the canonical Ethereum Classic chain at the designated fork block.  
-- To remain in consensus, node operators MUST upgrade to a client version that supports:
-  - EIP-1559 (`basefee` mechanism and Type-2 transactions)  
-  - EIP-3198 (`BASEFEE` opcode)  
-  - Consensus-layer `BASEFEE` redirection to the deterministic Treasury address defined in ECIP-1112  
-
-#### Compatibility Characteristics
-
-- **Legacy Contract Support** — Existing smart contracts and dApps function without modification.  
-- **Treasury Isolation** — The Treasury contract logic (ECIP-1112) is independent of application-layer behavior.  
-- **Transaction-Type Flexibility** — Users, miners, and developers may continue using Type-0 and Type-1 transactions if desired; Type-2 support is additive.
-
-As with ECIP-1112, any non-upgraded clients will fork permanently from the canonical chain at activation. All blocks, transactions, and state transitions on the minority fork will be invalid on the main chain.
+| Case                                                                                                                      | Expected                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Base-fee adjustment across empty, partial and full blocks                                                                 | matches EIP-1559 mechanics above the floor                                                                                                                                                                                                                                    |
+| Sustained empty blocks, 1,000 or more consecutive                                                                         | `baseFeePerGas` never falls below `MIN_BASE_FEE`                                                                                                                                                                                                                              |
+| **`MIN_BASE_FEE` configured strictly greater than `INITIAL_BASE_FEE`**                                                    | the fork block, and every subsequent block at or above target, MUST still return `MIN_BASE_FEE`. **A vector run only where the two constants are equal cannot distinguish an enforced floor from a coincidental one, and does not discharge this row**                        |
+| **`MIN_BASE_FEE` configured strictly below the parent's base fee, parent at target**                                      | result is the parent's base fee — the clamp raises, never lowers                                                                                                                                                                                                              |
+| **Decrease delta truncating to zero** (parent base fee small enough that `parentBaseFee ÷ 8` floors to 0, floor disabled) | base fee is **unchanged**, not decremented by 1. An implementation flooring the decrease delta at 1 MUST fail this vector                                                                                                                                                     |
+| Increase delta truncating to zero                                                                                         | base fee increases by exactly 1 — the `max(…, 1)` on the increasing path only                                                                                                                                                                                                 |
+| Fork block                                                                                                                | equals `max(INITIAL_BASE_FEE, MIN_BASE_FEE)`; `INITIAL_BASE_FEE` is applied once and is a distinct constant from the floor                                                                                                                                                    |
+| Vault credit, per transaction                                                                                             | after each transaction, the Vault's balance has increased by exactly that transaction's `gasUsed × block.baseFeePerGas`                                                                                                                                                       |
+| **Vault credit observed mid-block**                                                                                       | a transaction reading `BALANCE` of the Vault address observes the base fees of **all preceding transactions in the same block**. An implementation crediting a block-level total at finalization MUST fail this vector, and it is the vector that distinguishes the two rules |
+| **Vault credit under double accounting**                                                                                  | an implementation that credits per transaction _and_ adds a block-level total at finalization MUST fail                                                                                                                                                                       |
+| **Reverted transaction**                                                                                                  | consumes gas, pays the base fee, and credits the Vault exactly as a successful transaction does                                                                                                                                                                               |
+| EVM code executed by the credit                                                                                           | **none.** No fallback or `receive` body runs at the destination, no log is emitted, no gas is consumed, and the credit cannot revert. A vector asserting only the resulting balance does not discharge this row                                                               |
+| Miner credit                                                                                                              | `gasUsed × priorityFeePerGas` only; unaffected by the Vault credit                                                                                                                                                                                                            |
+| `BASEFEE` opcode (`0x48`)                                                                                                 | returns the current block's `baseFeePerGas`, including on the fork block                                                                                                                                                                                                      |
+| Every transaction type valid at the activation block                                                                      | the base fee applies uniformly across all of them, with legacy pricing handled per EIP-1559. **Vectors MUST be derived from the set the chain's active fork configuration admits at that block, rather than from a fixed enumeration here**                                   |
+| Fork ID                                                                                                                   | validates across the activation block                                                                                                                                                                                                                                         |
+| Both networks                                                                                                             | identical results on ETC Mainnet (chainId 61) and Mordor Testnet (chainId 63)                                                                                                                                                                                                 |
 
 ### Security Considerations
 
-The Olympia upgrade introduces no new consensus-critical vulnerabilities beyond those already inherent in EIP-1559 and EIP-3198. Both features are widely deployed across the EVM ecosystem and have undergone extensive testing, review, and validation. Security considerations for ECIP-1111 focus primarily on ensuring correct and consistent implementation of consensus-layer `BASEFEE` redirection.
+This ECIP introduces no consensus-critical logic beyond EIP-1559 and EIP-3198. The only functional deviation from Ethereum's own EIP-1559 is the destination of the base fee, enforced identically to any other consensus rule.
 
-#### 1. EIP-1559 and EIP-3198 Safety
+**The credit executes no EVM code, consumes no gas, and cannot fail.** It therefore introduces no new failure path into the state transition, and this ECIP's correctness does not depend on what is deployed at the destination address, on that contract's behavior, or on any later change to it. A contract at the address cannot refuse the credit, cannot observe it as it happens, and cannot cause a transaction to fail by receiving it. A compromise of that account therefore costs the balance held rather than the correctness of any block.
 
-- **Production Maturity** — EIP-1559 and the `BASEFEE` opcode have been active on Ethereum Mainnet since 2021 and are implemented across numerous EVM-based networks (e.g., BSC, Polygon, Arbitrum, OP Stack chains).
-- **Independent Validation** — These features have undergone formal analysis, multi-client testing, and long-term operational usage in production environments.
+**The failure mode that does exist is client divergence, and it is the ordinary one.** An implementation that credits a different amount, credits at a different point in the state transition, or performs the credit as a call rather than as a balance addition produces a different intermediate state, and forks. That risk is a risk of incorrect implementation rather than a novel vulnerability class, and §"Test Cases" carries a vector for each way of getting it wrong.
 
-#### 2. BASEFEE Redirection Logic
+### Implementation
 
-- **Single Consensus Deviation** — The only functional divergence from Ethereum Mainnet’s EIP-1559 behavior is that ETC redirects the `BASEFEE` amount to the Olympia Treasury (ECIP-1112) rather than burning it.
-- **Consensus Enforcement** — This redirection is enforced directly within the block finalization logic. All participating clients MUST apply identical state-transition rules to avoid consensus divergence.
-- **Treasury Immutability** — The Treasury contract defined in ECIP-1112 contains no upgrade mechanisms, administrative keys, or privileged withdrawal paths. It is a deterministic, immutable vault.
+Activation blocks are to be finalized through open coordination among client implementers, node operators, miners, exchanges, and infrastructure providers:
 
-#### 3. Client Implementation Requirements
+- **Mordor Testnet**: `TBD`
+- **ETC Mainnet**: `TBD`
 
-- **State-Transition Accuracy** — Clients MUST correctly compute and redirect the `BASEFEE` amount to the Treasury. Incorrect calculation or transfer risks:
-  - Rounding inconsistencies  
-  - Ledger imbalance  
-  - Block execution mismatches  
-- **Test Vector Updates** — Test vectors that assume `basefee` burning MUST be adapted to validate Treasury accumulation behavior.
-- **Cross-Client Alignment** — All clients MUST produce identical results for `basefee` calculation, transaction processing, and Treasury accumulation.
+**These blocks are recorded here and in no other document.**
 
-#### 4. Treasury Isolation
+**Cross-client agreement is evidence that this specification is unambiguous only where the implementations do not share a state-transition codebase.** Before this ECIP advances to `Final`, the vectors above MUST be executed on at least two implementations whose state-transition code derives from unrelated upstreams, and both the vectors and their results MUST be published as data a third party can re-execute.
 
-- **Execution Separation** — ECIP-1111 specifies only consensus-layer revenue redirection. No withdrawal or governance logic is included in this ECIP.
-- **Independent Governance** — Treasury spending and governance mechanisms are defined separately in ECIP-1112, ECIP-1113, and ECIP-1114. Their activation or operation does not alter the consensus rules introduced in ECIP-1111.
+### References
 
-#### 5. Testnet and Audit Strategy
+Where a third-party repository is cited, the ref is a commit rather than a branch or tag: a commit cannot move, while a branch resolves to different code over time and is therefore not a citation.
 
-- **Mordor Testnet Deployment** — All ECIP-1111 functionality MUST be validated on Mordor prior to Mainnet activation. Testing SHOULD include:
-  - Legacy (Type-0), Access List (Type-1), and EIP-1559 (Type-2) transaction handling  
-  - Accurate `BASEFEE` accounting  
-  - Treasury accumulation verification  
-  - `BASEFEE` opcode correctness  
-- **Audit Coordination** — Although ECIP-1111 affects consensus-layer logic only, its interaction with ECIP-1112 SHOULD be reviewed to ensure correct integration of Treasury accumulation mechanisms.
+1. EIP-1559, "Fee market change for ETH 1.0 chain" (Final), https://eips.ethereum.org/EIPS/eip-1559 — including the block-validation pseudocode whose per-transaction loop §"Consensus-Layer Redirection" extends
 
-#### Security Considerations Summary
+2. EIP-3198, "BASEFEE opcode" (Final), https://eips.ethereum.org/EIPS/eip-3198
 
-The Olympia upgrade activates established EVM improvements and introduces a single consensus-layer modification to redirect the `BASEFEE` amount to an immutable Treasury contract. The upgrade is fully additive, preserves all existing EVM semantics, and makes no changes to historical state or previously deployed contracts. With correct implementation, cross-client alignment, and thorough testnet validation, the consensus changes defined in ECIP-1111 can be adopted safely and predictably across the Ethereum Classic network.
+3. Nethermind, https://github.com/NethermindEth/nethermind @ `2706ce9e02` — the generic fee-collector mechanism named in §Rationale: the `feeCollector` and `eip1559FeeCollectorTransition` chain-specification parameters, and their application in the per-transaction fee payment. The Gnosis, Chiado, Taiko Alethia, Taiko Hoodi, POA Core and Linea chain specifications distributed with that client are where the per-network values in §Rationale are read
 
-### Related ECIPs in the Olympia Upgrade
+4. Erigon, https://github.com/erigontech/erigon @ `527e210d7a` — the `burntContract` chain-configuration parameter, a map from activation block to destination address, and its application in the per-transaction state transition. The Gnosis, Chiado, Polygon PoS and Polygon Amoy chain specifications distributed with that client are where those networks' values are read
 
-ECIP-1111 is one of four coordinated proposals that together define the Olympia upgrade path.  
-Only ECIP-1111 introduces a consensus-layer change. ECIP-1112, ECIP-1113, and ECIP-1114 operate entirely at the contract or application layer and do **not** require a network hard fork.  
-Although ECIP-1113 and ECIP-1114 are **not required for activation of ECIP-1111**, they are **required for any future Treasury disbursements**. Until those governance components are deployed, the Treasury defined in ECIP-1112 remains an immutable, non-spending vault.
+5. Foundry, https://github.com/foundry-rs/foundry @ `3c16e23` — `crates/cast/src/tx.rs` and `crates/forge/src/cmd/create.rs`, where a legacy transaction is sent only on an explicit flag or on a chain the registry reports as pre-EIP-1559. That registry is `alloy-rs/chains`, https://github.com/alloy-rs/chains @ `e30fd86`, whose `Chain::is_legacy()` returns `false` for any chain it does not name and which names none at chain ID 61
 
-- **[ECIP-1111 — Olympia EVM and Protocol Upgrades](https://ecips.ethereumclassic.org/ECIPs/ecip-1111)**  
-  Activates EIP-1559 and EIP-3198 on Ethereum Classic and redirects the `BASEFEE` amount to the Treasury instead of burning it.
+6. Polygon Improvement Proposal 24, "Change EIP-1559 Policy" (Final), https://github.com/0xPolygon/Polygon-Improvement-Proposals/blob/1b5292a57ac0846f4f9157062b9e7cd844713c5c/PIPs/PIP-24.md — the destination change quoted in §Rationale, and the statement that it is made by adding an entry to `burntContract` with a hard-fork block number
 
-- **[ECIP-1112 — Olympia Treasury Contract](https://ecips.ethereumclassic.org/ECIPs/ecip-1112)**  
-  Defines the deterministic, immutable Treasury contract that receives all redirected `BASEFEE` revenue and holds it in a governance-isolated vault.  
-  Without ECIP-1113 and ECIP-1114, the Treasury **can accumulate but cannot release funds**.
+7. Sky Mavis, `ronin-chain/ronin`, https://github.com/ronin-chain/ronin. The Layer 1 base-fee handling cited in §Rationale is at commits `e7ef8ca8c`, `37d10f703` and `eaef5a292`; the migration to a Layer 2 at `09f2d2d3c` and `fb7fc1fa8`. The two base-fee constants and their enforcement are read at `e8679e9f8`, `params/protocol_params.go` and `consensus/misc/eip1559/eip1559.go`. The repository is tagged, but its newest tag predates every commit cited here, so a commit is the only ref that reaches them
 
-- **[ECIP-1113 — Olympia DAO Governance Framework](https://ecips.ethereumclassic.org/ECIPs/ecip-1113)**  
-  Specifies the governance architecture that, once deployed, becomes the **required governance layer** for authorizing Treasury disbursements.
-  ECIP-1113 is optional relative to ECIP-1111 activation, but **mandatory for enabling any spending**.
+8. OP Stack Specification, Jovian execution engine, https://specs.optimism.io/protocol/jovian/exec-engine.html — the minimum-base-fee clamp cited in §Rationale. The value is configured in the `SystemConfig` contract, https://github.com/ethereum-optimism/optimism/blob/0f21af947798a94aa50e797c61f576ca18b1334d/packages/contracts-bedrock/src/L1/SystemConfig.sol, whose `setMinBaseFee(uint64)` is restricted to that contract's owner
 
-- **[ECIP-1114 — Ethereum Classic Funding Proposal Process](https://ecips.ethereumclassic.org/ECIPs/ecip-1114)**  
-  Defines the standardized, permissionless proposal format (ECFP) and the hash-bound execution model that ECIP-1113 uses to authorize Treasury disbursements.
+9. Base, "Network fees", https://docs.base.org/base-chain/network-information/network-fees — the 5,000,000 wei (0.005 gwei) figure, stated for both Base networks
 
-#### Interdependency Summary
+10. Ava Labs, `subnet-evm`, https://github.com/ava-labs/subnet-evm @ `edc9ebe712` — `commontype/fee_config.go`, the required, non-nil `MinBaseFee` field of every chain's fee configuration, and `precompile/contracts/feemanager/contract.go`, the `FeeManager` precompile whose `setFeeConfig` changes it under that precompile's allow-list
 
-- **ECIP-1111** introduces consensus-layer `BASEFEE` redirection to the Treasury.  
-- **ECIP-1112** deploys the immutable Treasury contract to receive and hold funds.  
-- **ECIP-1113** provides the governance framework that is **required for any Treasury withdrawals**.  
-- **ECIP-1114** defines the standardized proposal process that ECIP-1113 enforces for all disbursements.
+11. ECIP-1000, "ECIP Purpose and Guidelines"
 
-All four ECIPs are designed for **modular and independent activation**:
+12. ECIP-1017 (2016), "Monetary Policy and Final Modification to the Ethereum Classic Emission Schedule"
 
-- ECIP-1111 and ECIP-1112 MAY be activated first to begin revenue accumulation.  
-- ECIP-1113 and ECIP-1114 MAY be activated later, enabling controlled Treasury governance and disbursement **without requiring any changes to ECIP-1111**.
+13. Chainlist, "Ethereum Classic", https://chainlist.org/chain/61 — a stable address at which the public RPC endpoints currently serving chain ID 61 are listed. The set changes as operators start and stop serving, which is why this reference names the list rather than an endpoint. The endpoints a measurement is read from are an instrument and not evidence: the block headers §Rationale measures are canonical chain data, re-readable from any Ethereum Classic node.
 
 ### Copyright
 
-Copyright and related rights waived via  
+Copyright and related rights waived via
 [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-
-### Appendix: EVM Precedents for BASEFEE Redirection and EIP-1559 Adoption
-
-ECIP-1111 activates EIP-1559 and EIP-3198 on Ethereum Classic, with the modification that the `basefee` amount is redirected to the Treasury contract defined in ECIP-1112 rather than burned. While Ethereum Mainnet treats the `basefee` as a deflationary burn, several EVM networks use alternative designs that redirect protocol-level fee revenue or sequencer revenue toward governance-controlled treasuries. These precedents demonstrate the diversity of fee-handling models within the broader EVM ecosystem.
-
-#### Precedents for Protocol-Level Revenue Redirection
-
-| Network         | Fee / Revenue Mechanism                  | Governance Model                   | Notes                                                                 |
-|-----------------|-------------------------------------------|-------------------------------------|-----------------------------------------------------------------------|
-| **Ronin**       | EIP-1559 `basefee` redirected to treasury | Ronin DAO (Snapshot + Multisig)     | Direct example of basefee redirection rather than burning             |
-| **Celo**        | Gas fees routed to Gas Fee Handler        | Celo Governance                     | Non-1559 mechanism for funding community and climate initiatives      |
-| **Mantle**      | Sequencer revenue to DAO treasury         | Mantle Governance                   | L2-style revenue sharing; not EIP-1559 `basefee`                      |
-| **Polygon CDK** | Optional fee hooks                        | Rollup-local DAO governance         | Sovereign rollups may implement basefee-like hooks                    |
-| **OP Stack**    | Sequencer revenue sharing                 | L2-local DAO governance             | Revenue allocation for public goods; not EIP-1559 `basefee`           |
-| **Arbitrum**    | Sequencer revenue to DAO treasury         | Arbitrum DAO                        | Uses AIP process; not EIP-1559 `basefee`                              |
-| **Optimism**    | Sequencer revenue to RPGF                 | Bicameral DAO                       | Retroactive public goods funding                                      |
-
-#### Lessons Applied in ECIP-1111
-
-- **Protocol-Layer Enforcement** — ECIP-1111 redirects the `basefee` amount at the consensus layer, ensuring the behavior is deterministic and identical across all participating clients.
-- **Consistency with Existing EIPs** — ECIP-1111 retains all other EIP-1559 semantics, including dynamic `basefee` adjustment, transaction pricing, and tip handling.
-- **Deterministic Treasury Address** — ECIP-1112 defines a fixed, consensus-recognized Treasury address to ensure consistent behavior across clients.
-- **Modular Governance Separation** — ECIP-1111 implements revenue redirection only. Governance mechanisms for Treasury withdrawals are defined separately in ECIP-1113 and ECIP-1114 and are not part of this ECIP.
-
-ECIP-1111 adapts the established EIP-1559 fee market to route value to an immutable, protocol-defined Treasury contract rather than burning it, enabling transparent and auditable accumulation of consensus-layer revenue while preserving Ethereum Classic’s Proof-of-Work and immutability guarantees.
-
-### Appendix: EVM Compatibility Roadmap and Upgrade Candidates
-
-#### Future Considerations: Toward Full EVM Compatibility
-
-The Olympia Upgrade is intentionally limited in scope to EIP-1559 and EIP-3198. However, additional Ethereum protocol improvements have been reviewed as potential candidates for future consideration. The table below categorizes EIPs based on their technical compatibility with Ethereum Classic’s Proof-of-Work model and their relevance to developer tooling and interoperability.
-
-> *Note:* The EIPs listed below are **not** included in ECIP-1111. Adoption of any additional EIPs would require a separate ECIP, independent community review under ECIP-1000, and successful Mordor Testnet validation before Mainnet activation.
-
-#### ✅ Candidates for Future Evaluation
-
-These EIPs appear technically compatible with ETC’s Proof-of-Work design and may improve developer experience or EVM alignment without introducing breaking changes:
-
-| EIP    | Title                                   | Notes                                                                                           |
-|--------|-----------------------------------------|-------------------------------------------------------------------------------------------------|
-| 1283   | SSTORE Gas Metering Changes             | Improves storage efficiency; widely supported by tooling; considered low-risk and high-utility.|
-| 5656   | MCOPY Memory Instruction                | Performance optimization; beneficial for modern EVM workloads including zk-related tooling.     |
-| 6780   | SELFDESTRUCT Semantics Change           | Aligns with Shanghai semantics; removes non-deterministic contract deletion; requires review.   |
-| 1153   | Transient Storage Opcodes               | Adds ephemeral storage support used in modern dApp patterns; no impact on PoW consensus.        |
-| 2935   | Save Historical Block Hashes in State   | Provides access to past block hashes for certain oracle-like use cases; optional enhancement.   |
-| 7623   | Increase Calldata Cost                  | Adjusts calldata gas costs; relevant for reducing calldata-intensive patterns; PoW-tunable.     |
-
-#### ⚠️ Optional or Lower Priority
-
-These EIPs have limited impact or depend on ecosystem factors not currently present on ETC:
-
-| EIP    | Title                         | Notes                                                                              |
-|--------|-------------------------------|------------------------------------------------------------------------------------|
-| 170    | Contract Code Size Limit      | Mitigates contract bloat; ETC has not seen high-volume DoS patterns.              |
-| 3228   | Difficulty Bomb Delay         | Specific to Ethereum’s PoS transition; not applicable to ETC’s PoW model.         |
-| 7691   | Blob Throughput Increase      | Depends on EIP-4844 blob support, which ETC does not currently implement.         |
-| 7702   | Set EOA Account Code          | Supports account abstraction; not currently a priority for ETC.                   |
-
-#### ❌ Incompatible or Out of Scope (PoS-Specific or High-Risk)
-
-These EIPs require consensus structures incompatible with ETC’s Proof-of-Work model or introduce architectural assumptions ETC does not share:
-
-| EIP(s)                                              | Reason for Exclusion                                                                                                      |
-|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| 3675, 4895, 4788, 4399, 6110, 7251, 7549, 7002, 7685, 7840 | Depend on Ethereum’s Proof-of-Stake, beacon chain, or validator lifecycle; incompatible with ETC’s PoW consensus.       |
-| 4844, 7516                                          | Require blob transaction support and related consensus infrastructure; high complexity and low relevance for ETC today.   |
-| 2537                                                | Introduces BLS12-381 precompiles primarily used for PoS validator duties; expands cryptographic surface area unnecessarily. |
-
-Community members are encouraged to submit ECIPs for any desired EVM upgrade using the standard process, prioritizing compatibility, security, and Ethereum Classic’s Proof-of-Work integrity.

--- a/_specs/ecip-1111.md
+++ b/_specs/ecip-1111.md
@@ -61,7 +61,7 @@ self.account(SOVEREIGNTY_VAULT).balance += gas_used * block.base_fee_per_gas
 
 **The second line is the whole of the change**, including EIP-1559's own base-fee adjustment arithmetic, which is unchanged.
 
-**The credit is per transaction. Implementations MUST NOT compute it as a single block-level product at finalization**, and MUST NOT do both. `block.gasUsed × block.baseFeePerGas` yields the same total for the block, so the two rules agree on the state root at a block boundary and disagree everywhere inside one: under this ECIP, transaction _N+1_ observes a Vault balance that already carries the base fees of transactions _1..N_ of the same block, and that balance is readable by `BALANCE` and `SELFBALANCE`.
+**The credit is per transaction. Implementations MUST NOT compute it as a single block-level product at finalization**, and MUST NOT do both. `block.gasUsed × block.baseFeePerGas` yields the same total for the block, so the two rules agree on the state root at a block boundary and disagree everywhere inside one: under this ECIP, transaction _N+1_ observes a Vault balance that already carries the base fees of transactions _1..N_ of the same block, and that balance is readable by `BALANCE`.
 
 **The amount credited MUST equal the base fee charged to the sender for that transaction**, computed on the same gas quantity that transaction contributes to `block.gasUsed`.
 
@@ -187,6 +187,10 @@ This ECIP introduces no consensus-critical logic beyond EIP-1559 and EIP-3198. T
 **The credit executes no EVM code, consumes no gas, and cannot fail.** It therefore introduces no new failure path into the state transition, and this ECIP's correctness does not depend on what is deployed at the destination address, on that contract's behavior, or on any later change to it. A contract at the address cannot refuse the credit, cannot observe it as it happens, and cannot cause a transaction to fail by receiving it. A compromise of that account therefore costs the balance held rather than the correctness of any block.
 
 **The failure mode that does exist is client divergence, and it is the ordinary one.** An implementation that credits a different amount, credits at a different point in the state transition, or performs the credit as a call rather than as a balance addition produces a different intermediate state, and forks. That risk is a risk of incorrect implementation rather than a novel vulnerability class, and §"Test Cases" carries a vector for each way of getting it wrong.
+
+#### Step Changes to the Minimum Base Fee
+
+A future hard fork that changes `MIN_BASE_FEE` applies the new value as an immediate step at the activation block, with no EIP-1559-style adjustment ramp. This is consistent with the fork block itself, where `INITIAL_BASE_FEE` is applied as a discontinuous jump from no base fee to 1 gwei. Both are consensus parameter changes gated by hard fork, and both take effect at a single block by design. Smoothing a floor change would introduce transition-state tracking not required by any other rule in this ECIP, contradicting its minimal-surface intent. This is an accepted design property, not an omission.
 
 ### Implementation
 


### PR DESCRIPTION
Updates ECIP-1111 to the post-implementation draft, reflecting the specification as built rather than as originally proposed.

Title is now **Base Fee Market and Redirection**, which states what the proposal specifies.
