### PR TITLE
spec(ecip-1112): update to post implementation draft

### DIFF
--- a/_specs/ecip-1112.md
+++ b/_specs/ecip-1112.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 ecip: 1112
-title: Olympia Treasury Contract
+title: Sovereignty Vault
 status: Draft
 type: Standards Track
 category: Core
@@ -14,498 +14,152 @@ license: CC0-1.0
 
 ### Simple Summary
 
-Redirect all `BASEFEE` amounts introduced by ECIP-1111 to a deterministic, immutable smart contract — the **Olympia Treasury** — instead of burning them. The Treasury functions as a governance-isolated vault that can receive protocol-level revenue but cannot be modified or accessed except through a single, authorized execution entry point defined in a separate governance ECIP.
+Establishes the **Sovereignty Vault**: the permanent address at which Ethereum Classic's base-fee revenue accumulates.
+
+The network makes one address permanent. It is written into every client's chain configuration by the hard fork that activates [ECIP-1111](https://ecips.ethereumclassic.org/ECIPs/ecip-1111), and a further fork is what changes it. A stock OpenZeppelin transparent proxy is deployed at that address, so the logic behind it can be repaired while the address stands.
+
+**One address holds one balance.** "Sovereignty Vault" names that address and the revenue ECIP-1111 credits to it. This ECIP states what must be true of the account there before the network commits to the address, and what must be published so anyone can confirm it from chain state; it specifies no governance machinery.
 
 ### Abstract
 
-This ECIP defines the deployment of the **Olympia Treasury**, a deterministic and immutable smart contract that receives all `BASEFEE` amounts redirected under ECIP-1111. The Treasury is deployed at a fixed address, derived deterministically, and is hardcoded as the canonical recipient of protocol-level revenue. It functions exclusively as a governance-isolated vault: it may receive funds, but it cannot be upgraded, modified, or accessed directly.
+This ECIP defines the Sovereignty Vault: the address to which [ECIP-1111](https://ecips.ethereumclassic.org/ECIPs/ecip-1111) credits the base fee charged to every transaction. That ECIP states the consensus rule and the chain-configuration parameter holding the address; this one states what must be true of the account at it.
 
-The Treasury exposes a minimal, restricted interface that accepts revenue transfers and permits withdrawals only from a single, authorized execution entry point defined in separate governance ECIPs. No governance logic, proposal processing, or allocation rules are implemented within this contract. Its sole purpose is to provide a transparent, auditable, and immutable custody layer for protocol-level funds.
-
-This ECIP does not introduce consensus behavior beyond that defined in ECIP-1111, and it does not define how funds are allocated or governed. Those mechanisms are specified independently in downstream ECIPs.
+Three requirements, and nothing above them: the account is deployed, locked, and inspectable on-chain before the fork commits to the address; every implementation ever deployed there derives spendable value from the account's balance; and enough is published that a third party can confirm both from chain state. Governance of the account and allocation of the balance are specified elsewhere. This ECIP introduces no consensus behavior.
 
 ### Motivation
 
-Ethereum Classic requires a transparent and protocol-native method to retain the `BASEFEE` amounts introduced under ECIP-1111. Because Ethereum Mainnet burns the `BASEFEE`, a deterministic mechanism is needed on Ethereum Classic to receive and hold this value at the protocol level without altering monetary policy or relying on discretionary off-chain actors.
+The base fee ECIP-1111 credits is capital the network raises from its own usage, with no foundation, sponsor, or donor in the path. The destination holding it answers to two requirements whose lifetimes differ.
 
-A contract-based Treasury provides this functionality by:
+**The address is permanent.** Execution clients carry it in chain configuration, so redirecting the network's revenue costs a coordinated client release, and no on-chain party can do it at all.
 
-- Offering an immutable, governance-isolated location for protocol revenue.
-- Ensuring that accumulated funds are custodied transparently and audited on-chain.
-- Providing a deterministic address that all upgraded clients can reference consistently.
-- Enforcing strict separation between fund custody (this ECIP) and any governance or allocation logic (defined in separate ECIPs).
+**The logic behind the address is repairable.** The contract at the network's revenue destination must be able to take a security patch, a response to a disclosed vulnerability, and a major-version migration of its own dependencies. A design that needs a hard fork for each of those makes a chain split the routine response to a routine defect.
 
-By deploying a minimal, immutable vault contract, Ethereum Classic gains a durable mechanism for securely accumulating protocol-level revenue while preserving consensus neutrality and avoiding any implicit trust in privileged intermediaries. This enables the network to adopt `BASEFEE` redirection under ECIP-1111 without introducing governance or execution semantics into the consensus layer.
+An upgradeable proxy holds both at once, and the remainder of this ECIP specifies the conditions that keep the separation sound.
 
 ### Specification
 
-#### Treasury Address
+#### The Address
 
-The Olympia Treasury contract SHALL be deployed at a **fixed, deterministic address**.  
-This address SHALL be derived using a reproducible method (e.g., `CREATE2`) and SHALL be publicly documented prior to testnet activation.
+[ECIP-1111](https://ecips.ethereumclassic.org/ECIPs/ecip-1111) §"The Destination Address" states the consensus parameter: `SOVEREIGNTY_VAULT` holds one address per network in the chain specification each participating client ships. ECIP-1111 delegates publication of the value to this ECIP, and §Implementation is the list of what is published.
 
-Upon activation of ECIP-1111, all `BASEFEE` amounts defined in that ECIP SHALL be transferred to this address at the consensus layer.
+#### What Is Deployed There
 
-Client implementations MUST treat this address as the canonical recipient of protocol-level `BASEFEE` revenue.
+**The account at the address MUST be an upgradeable proxy with the three properties below**, each of them readable from chain state:
 
-#### Deterministic Deployment
+- **The implementation is replaceable and the address is not.** The implementation address is held in the ERC-1967 implementation slot, and replacing it leaves the account's address and its balance untouched.
+- **Upgrade authority is fixed at construction and cannot be repointed.** The account names the holder of upgrade authority when it is constructed and exposes no path to change it afterwards, so no party acting through the account can move the authority to replace the implementation.
+- **Upgrade authority reaches nothing else through the account.** A call from the holder of upgrade authority either replaces the implementation or reverts, and is never forwarded to the implementation.
 
-The Treasury contract’s address derivation MUST be identical across all client implementations.  
-The derivation method SHALL:
+**OpenZeppelin's `TransparentUpgradeableProxy` has all three, and is what the deployment uses**, unmodified. It holds the implementation address in the ERC-1967 implementation slot; it deploys its own `ProxyAdmin` and stores that address in an immutable field, `ProxyAdmin` being `Ownable` with `upgradeAndCall` restricted `onlyOwner`; and a call from that contract which is not `upgradeToAndCall` reverts with `ProxyDeniedAdminAccess()`. OpenZeppelin warns that adding an external function to the proxy can shadow `upgradeToAndCall` through a selector clash and leave the account permanently unupgradeable, which is why it is deployed stock. The reference below reads it at release v5.3.0.
 
-- Use a fixed deployer address  
-- Use a fixed, published salt  
-- Use the `keccak256` hash of the final Treasury contract bytecode  
+Which contracts sit beneath the implementation, which release each is deployed from, and where upgrade authority rests, are specified with that deployment and published under §Implementation.
 
-An implementation MAY use `CREATE` or `CREATE2`, but the resulting address MUST be predetermined and published in advance of deployment.
+**`GHSA-9rcw-c2f9-2j55` (CVE-2025-54070) does not reach this contract at any release.** It affects `>= 5.2.0, < 5.4.0`, and the vulnerable code is `lastIndexOf` in `utils/Bytes.sol`, which is absent from the proxy's transitive import closure at every release in that range and at every release since, through v5.7.0. That file enters the library at v5.2.0, the advisory's own floor, so there is no earlier release at which the question arises. The same walk finds that file inside `Governor`'s closure at v5.4.0, so it distinguishes rather than reporting absence everywhere. The closure of the contracts deployed beneath the proxy is not specified by this ECIP, and MUST be checked on its own terms before Mainnet deployment.
 
-A reference derivation method is provided below:
+One requirement binds every implementation deployed there, now and after any later replacement of its logic: §"Balance Is the Source of Truth".
 
-```solidity
-address computedAddress = address(
-    uint160(uint256(
-        keccak256(
-            abi.encodePacked(
-                bytes1(0xff),
-                deployerAddress,
-                salt,
-                keccak256(bytecode)
-            )
-        )
-    ))
-);
-```
+#### Balance Is the Source of Truth
 
-This code is illustrative only; client implementations SHALL rely on the published final address.
+**Every implementation deployed at the Vault address MUST determine spendable value from the account's own balance, and every upgrade MUST preserve that property.**
 
-#### Consensus-Layer Funding Source
+ECIP-1111's credit is a direct state write performed by the client during the transaction's state transition. It executes no EVM code: no `receive()` body runs, no fallback is entered, no event fires, and no counter is incremented. **An implementation that released funds against a total it maintained itself would release nothing, and the consensus-credited balance would be permanently unspendable.**
 
-Upon activation of ECIP-1111:
+An implementation satisfying this maintains no balance ledger and spends the account's real balance when it acts. An upgrade proposal MUST be rejected if the implementation it installs introduces a deposit counter, a running total of received value, or any other state variable mirroring the balance.
 
-- The full `basefee`-derived amount from each EIP-1559 transaction **MUST** be credited to the Treasury address at the consensus layer.  
-- This transfer **SHALL** occur during block finalization. Clients that omit, alter, or redirect this behavior **SHALL** fork from the canonical chain.
+Two shipped contracts carry the pattern this excludes. OpenZeppelin's `Escrow` credits `_deposits[payee]` inside `deposit(address payee) public payable`, and Liquity's `ActivePool` credits `uint256 internal ETH` inside `receive() external payable`. Each counter rises only in a call, and a consensus-layer credit makes none.
 
-ECIP-1112 defines:
+#### Deployment and Publication
 
-- the immutable Treasury contract,
-- the consensus-layer requirement that 100% of the `basefee`-derived amount be deposited into it, and
-- the single authorized withdrawal entry point.
+**The activation fork is the last step.** It commits to an address whose contents are already deployed and inspectable.
 
-All allocation, smoothing, or redistribution of Treasury-held BASEFEE — including mechanisms
-defined in ECIP-1114 and ECIP-1115 — occurs strictly **after** deposit and must use the
-governance-controlled execution pathway defined in ECIP-1113. ECIP-1112 itself implements
-no allocation logic or distribution rules.
+Two orderings are the requirement, and each is checkable from chain state:
 
-No additional revenue sources are defined in this ECIP.
+- **The account is complete before the address is published.** The published address MUST resolve to deployed code already in its final configuration, holding only the roles its own specification requires — at the moment of publication and at the activation block alike.
+- **The address is published before the activation block is scheduled**, so that the network commits to an address the public has already had the opportunity to inspect.
 
-#### Contract Requirements
-
-The Olympia Treasury contract MUST satisfy the following constraints.
-
-##### Immutability
-
-The contract:
-
-- MUST NOT contain upgrade mechanisms, proxy patterns, `delegatecall`, or `selfdestruct`.  
-- MUST be deployed exactly once.  
-- MUST NOT allow modification of authorization or upgrade-related state variables.
-
-##### Minimal Responsibilities
-
-The Treasury contract MUST:
-
-- Accept incoming ETC transfers, including consensus-directed `BASEFEE` redirection.  
-- Expose its balance publicly through standard EVM semantics.  
-- Provide a **single** restricted withdrawal entry point callable only by the authorized governance executor defined in separate ECIPs.
-
-The Treasury contract MUST NOT:
-
-- Perform governance, voting, proposal validation, or metadata verification.  
-- Perform accounting logic beyond optional duplicate-execution prevention.  
-- Modify consensus-layer fee rules or participate in fee calculation.  
-- Emit governance-level events or track proposal metadata.
-
-#### Access Control
-
-The Treasury contract MUST:
-
-- Restrict withdrawals to a single, authorized caller address.  
-- Reject all direct withdrawal attempts from EOAs.  
-- Reject calls from contracts other than the authorized governance executor.
-
-This ECIP does **not** define the governance executor contract or its lifecycle; those are specified in ECIP-1113.
-
-#### Minimal Reference Interface
-
-A minimal Treasury interface MAY be expressed as:
-
-```solidity
-interface ITreasury {
-    function release(address recipient, uint256 amount) external;
-}
-```
-
-The `release()` function:
-
-- MUST transfer the specified amount to `recipient` only if `msg.sender` is the authorized executor.  
-- MAY internally track identifiers to prevent duplicate execution.  
-- MUST NOT implement proposal validation, metadata hashing, or governance logic.
-
-No additional externally callable methods SHALL be exposed.
-
-#### Event Emission
-
-The Treasury contract MUST emit events sufficient for basic auditability.  
-At minimum:
-
-- `FundsReleased(address indexed recipient, uint256 amount)`  
-- `Received(address indexed from, uint256 amount)`
-
-These events MUST NOT include governance metadata or proposal identifiers, which are defined in ECIP-1113 and ECIP-1114.
-
-#### Out-of-Scope Elements
-
-The Treasury contract MUST NOT implement:
-
-- Proposal hashing or metadata binding  
-- ECFP lifecycle logic  
-- Governance decision-making  
-- Timelock, voting, queueing, or scheduling  
-- Role delegation or admin key models  
-- Off-chain integrations  
-- Legal entity handling  
-- Fee smoothing, escrow logic, or L-curve mechanics  
-
-These functions are defined exclusively in downstream ECIPs.
+The steps that produce that account, the roles granted between its contracts, and the invariants a deployer verifies against them are properties of those contracts and are specified with them. **What this ECIP requires is that all of it be complete, and independently checkable, before the network commits to the address.**
 
 ### Rationale
 
-#### Minimal, Immutable Architecture
+**The commitment is an address because an address is what a client can hold.** Execution clients carry a destination address in their chain configuration; they cannot carry the logic behind it. Permanence therefore attaches to the thing clients actually carry, and extending it to the logic would add a constraint the consensus layer never asked for, at the cost of the ability to repair.
 
-The Olympia Treasury is intentionally designed as a minimal, immutable contract whose sole role is to receive and hold protocol-level `BASEFEE` revenue redirected under ECIP-1111. By excluding governance logic, proposal handling, or metadata processing, the Treasury remains simple, auditable, and resistant to operational or upgrade-related risks.
+**A proxy is a safe consensus-credit target because the credit executes no EVM code.** ECIP-1111 requires a direct balance addition, so the proxy's payable fallback never runs, no delegation to the implementation occurs, no gas is consumed, and the credit cannot revert. The upgradeable surface and the consensus rule therefore do not touch: no upgrade can introduce a revert path into the state transition, because the state transition never calls the account. **What an upgrade can reach is accounting**, which is why §"Balance Is the Source of Truth" binds every implementation rather than only the first.
 
-A minimal vault architecture provides:
-
-- **Safety at activation** — No logic beyond accepting and releasing funds reduces the chance of deployment-time vulnerabilities.
-- **Long-term stability** — With no upgrade paths or privileged roles, the Treasury remains reliable throughout the lifecycle of the protocol.
-- **Deterministic and verifiable behavior** — All clients interact with the same immutable contract at a fixed address.
-
-This approach limits the attack surface and ensures that the Treasury can safely begin accumulating funds before any governance mechanism is deployed.
-
-#### Separation of Concerns
-
-Strict separation between custody (ECIP-1112) and governance (ECIP-1113/1114) is a core design principle.  
-This separation ensures:
-
-- The Treasury does not depend on the lifecycle, parameters, or implementation details of future governance systems.
-- Governance upgrades or replacements can occur without modifying the Treasury contract.
-- Consensus-layer behavior remains fully isolated from application-layer governance logic.
-
-The Treasury exposes only one restricted withdrawal entry point, callable by an external executor defined in separate ECIPs. This creates a clear boundary between value custody and decision-making.
-
-#### Deterministic Deployment and Client Consistency
-
-A fixed, deterministic Treasury address is necessary for:
-
-- **Consensus-layer correctness** — Clients must transfer `BASEFEE` revenue to an identical address to maintain consensus.
-- **Cross-client interoperability** — Deterministic address derivation prevents divergence between implementations.
-- **Auditability** — Participants can reliably verify inflows and contract behavior across all clients.
-
-Using deterministic deployment via `CREATE2` further guarantees that the published address can be reproduced independently.
-
-#### Transparent, Protocol-Level Fund Custody
-
-Redirecting the `BASEFEE` to a contract rather than burning it requires an on-chain location that is:
-
-- Publicly visible  
-- Immutable  
-- Programmatically accessible  
-- Free of discretionary control  
-
-The Treasury contract satisfies these requirements by acting solely as a transparent ledger entry that accumulates protocol-level value without applying any discretionary logic to it.
-
-#### Rationale Summary
-
-The Treasury’s design emphasizes immutability, minimalism, and strict separation from governance.  
-This ensures that protocol-level revenue redirected under ECIP-1111 is held securely and transparently, while leaving all governance, allocation, and proposal processes to independently defined ECIPs.  
-By maintaining this separation, Ethereum Classic gains a durable and verifiable foundation for protocol-level fund custody without introducing dependencies, privileged roles, or upgradeable components into the vault itself.
-
-### Related Work
-
-Several EVM-based networks use contract-based mechanisms to receive protocol-level fees or revenue at deterministic, on-chain addresses. These patterns demonstrate the viability of directing endogenous network value into immutable or minimally permissioned contracts for transparent custody.
-
-Examples include:
-
-- **Ronin Network**  
-  Implements EIP-1559-style `BASEFEE` redirection into a contract-based treasury rather than burning the fee.
-
-- **Celo (Layer 1)**  
-  Routes gas fees to a fixed contract (Gas Fee Handler) that acts as an on-chain sink for protocol-level value.
-
-- **Mantle (Layer 2)**  
-  Directs sequencer revenue into a deterministic on-chain vault contract.
-
-- **Polygon (Layer 2)**  
-  Uses contract-based treasuries for receiving protocol-level revenue defined by network rules.
-
-- **Arbitrum**  
-  Sends sequencer revenue to a deterministic contract address for transparent custody.
-
-- **Optimism**  
-  Uses on-chain sinks for sequencer revenue prior to any governance or allocation logic.
-
-Although these systems differ in governance structure and distribution logic—topics defined separately in ECIP-1113 and ECIP-1114—they share a common architectural pattern relevant to ECIP-1112:  
-**protocol-level revenue is routed to a deterministic, immutable contract that serves as a transparent custody layer.**
-
-This approach has proven reliable across multiple EVM ecosystems and informs the design choice to implement the Olympia Treasury as a minimal, immutable vault contract with a fixed, reproducible address.
-
-### Implementation
-
-The Olympia Treasury is implemented as a deterministic, immutable smart contract deployed at a fixed address.  
-Consensus-layer redirection of the `BASEFEE` amount is defined in ECIP-1111; this ECIP (1112) specifies only the contract that receives those funds.
-
-#### Client Responsibilities
-
-All Ethereum Classic client implementations MUST:
-
-- **Hardcode the Treasury address**  
-  Clients MUST treat the published Treasury address as the canonical destination for protocol-level `BASEFEE` revenue following activation of ECIP-1111.
-
-- **Apply consensus-layer redirection**  
-  During block finalization, clients MUST credit the full `BASEFEE` amount to the Treasury address in accordance with ECIP-1111.  
-  Clients MUST NOT expose alternative behaviors (e.g., burning).
-
-- **Maintain full EIP-1559 semantics**  
-  Clients MUST preserve all EIP-1559 rules for calculating the `basefee` and miner priority fees, with the only modification being the redirection of the `BASEFEE` component to the Treasury address.
-
-Failure to implement this behavior precisely SHALL result in a consensus fork.
-
-#### Deployment Artifacts
-
-Prior to activation on testnet and mainnet, the following SHALL be published:
-
-- The Treasury contract’s **bytecode**
-- The selected deployment method (`CREATE` or `CREATE2`)
-- The **fixed, deterministic address**
-- The derivation parameters (e.g., deployer address and salt), if using `CREATE2`
-
-Deterministic publication of these artifacts ensures cross-client reproducibility and enables consistent verification by implementers and auditors.
-
-#### Test Coverage and Validation
-
-Testing MUST validate the following behaviors:
-
-1. **Correct Consensus Redirection**  
-   Each client MUST correctly compute the `BASEFEE` amount and transfer it to the Treasury address in every post-activation block.
-
-2. **Cross-Client Consistency**  
-   All upgraded clients MUST produce identical state transitions and balances for the Treasury address under shared test vectors.
-
-3. **Event Emission**  
-   The Treasury contract MUST emit its defined events (`FundsReleased`, `Received`) during relevant operations and MUST NOT emit governance-related metadata.
-
-4. **Access Control Behavior**  
-   The Treasury contract MUST accept incoming transfers from consensus-layer redirection and MUST reject unauthorized withdrawal attempts.
-
-5. **Reproducible Deployment**  
-   The published deployment parameters MUST reproduce the exact Treasury address across all client implementations.
-
-These tests ensure that the Olympia Treasury behaves as a minimal, deterministic vault compatible with ECIP-1111’s consensus-layer rules and suitable for integration with the governance executor defined in ECIP-1113.
-
-#### Implementation Summary
-
-This ECIP defines the immutable contract that receives protocol-level `BASEFEE` revenue.  
-Client software is responsible only for:
-
-- redirecting `BASEFEE` to this contract, and  
-- ensuring consistent state-transition behavior across implementations.
-
-All governance logic, proposal processing, and withdrawal authorization are defined outside this ECIP.
-
-### Modular Treasury Deployment
-
-The Olympia Treasury is implemented as a standalone, immutable smart contract.  
-It MAY be deployed and activated independently of any downstream governance components defined in separate ECIPs.  
-This separation enables a phased rollout consistent with the modular activation strategy introduced in ECIP-1111.
-
-#### Pre-Governance Activation
-
-Upon activation of ECIP-1111, the Treasury SHALL begin passively accumulating `BASEFEE` revenue.  
-No governance contracts or auxiliary infrastructure are required for the Treasury to function as a secure, protocol-level vault during this phase.
-
-#### Security During the Accumulation Phase
-
-At deployment, the Treasury’s authorized executor address SHALL be configured to a value that **cannot satisfy** the contract’s access control checks.  
-Until a valid executor is established under a separate governance ECIP, the Treasury’s withdrawal entry point MUST NOT be callable by any account or contract.  
-Any attempted withdrawal from unauthorized addresses MUST revert.
-
-This configuration ensures that all accumulated funds remain securely locked, regardless of the timing or readiness of governance systems.
-
-#### Deployment Advantages
-
-- **Forward Compatibility** — The Treasury can operate unchanged across future governance upgrades because it contains no governance logic of its own.
-- **Security Isolation** — The Treasury’s immutability and minimalism reduce the attack surface during the period before governance deployment.
-- **Phased Rollout Support** — ECIP-1111 and ECIP-1112 can be activated as soon as they are ready, while governance mechanisms defined in other ECIPs can be deployed, audited, and reviewed independently.
-
-This modular deployment model ensures that protocol revenue capture can begin immediately once ECIP-1111 is active, without requiring simultaneous activation of governance or proposal systems.
+**Ethereum Classic's governance model is what puts the destination in chain configuration.** On the production networks [ECIP-1111](https://ecips.ethereumclassic.org/ECIPs/ecip-1111) §Rationale tabulates, the destination is a configuration value some authority already controls — a chain owner, a multisig, a proxy administrator, an allow-list admin — so immutability there buys nothing, that authority being able to change the configuration regardless. **Ethereum Classic has no such authority**, which inverts the trade: a destination an on-chain party could repoint would create one, able to redirect the network's entire revenue without the fork that installed the address.
 
 ### Backwards Compatibility
 
-ECIP-1112 introduces no changes to transaction formats, opcode behavior, or EVM semantics.  
-It defines only the immutable Treasury contract that receives the `BASEFEE` amounts redirected by ECIP-1111.  
-All consensus-layer changes related to `BASEFEE` handling are specified exclusively in ECIP-1111.
+This ECIP introduces no changes to transaction formats, opcodes, or EVM semantics; all consensus-layer behavior is ECIP-1111's, and its §"Backwards Compatibility" governs those. Existing transactions and contracts are unaffected. Tooling that displays or attributes fee flows needs updating for one change this ECIP makes visible: the base fee accrues to an account, and that account's balance is where it is observed.
 
-#### Node Behavior
+### Test Cases
 
-- **Upgraded Clients**  
-  Clients that implement ECIP-1111 and recognize the Treasury address defined in this ECIP will:
-  - Process Type-0 (Legacy), Type-1 (Access List), and Type-2 (EIP-1559) transactions correctly.
-  - Redirect the computed `BASEFEE` amount to the Treasury address during block finalization.
+**What a conforming deployment looks like from chain state**, read at the published address before the activation block and re-established after every upgrade:
 
-- **Non-Upgraded Clients**  
-  Clients that do not implement ECIP-1111 and ECIP-1112 will:
-  - Fail to process Type-2 transactions correctly.
-  - Continue burning or mishandling the `BASEFEE`.
-  - Remain unaware of the Treasury contract address.
+| Read | Expected |
+|---|---|
+| The implementation's storage layout | no deposit counter, running total, or other state mirroring the balance (§"Balance Is the Source of Truth") |
+| The role table of the account | the roles its own specification requires, and no role that existed only to construct the deployment |
 
-  Such clients will diverge at the activation block, forming a **permanent consensus fork**.
+**What a conforming client does with it**, run against the deployed proxy and a client implementing ECIP-1111:
 
-#### Contract and Tooling Compatibility
-
-- **Legacy Transactions**  
-  Type-0 transactions remain valid and unaffected.
-
-- **Access List Transactions (Type-1)**  
-  Type-1 transactions introduced by ECIP-1103 remain valid and unaffected, as ECIP-1112 adds no new semantics for transaction execution.
-
-- **Existing Contracts**  
-  Smart contracts that do not reference the `BASEFEE` or the Treasury address continue to function unchanged.
-
-- **Tooling and dApps**  
-  Applications that do not rely on EIP-1559 semantics remain fully functional.  
-  Tooling that supports Type-2 transactions (EIP-1559) MAY require updates to reflect that Ethereum Classic redirects the `BASEFEE` to the Treasury address rather than burning it, as defined in ECIP-1111.  
-  No changes are required for transaction submission or execution semantics.
-
-- **Treasury Contract Independence**  
-  The Treasury contract can securely accumulate funds even if downstream governance contracts defined in other ECIPs are not yet deployed.
-
-This ECIP preserves backward compatibility for all existing transaction types and smart contracts.  
-Only clients that fail to upgrade to support ECIP-1111 and recognize the Treasury address defined here will fork from the canonical chain at activation.
+| Case | Expected |
+|---|---|
+| Consensus credit, and the code that credit executes | as [ECIP-1111](https://ecips.ethereumclassic.org/ECIPs/ecip-1111) §"Test Cases" specifies — the per-transaction credit amount, and the requirement that the credit execute no EVM code, carried there at its `Vault credit, per transaction` and `EVM code executed by the credit` rows — with the deployed proxy as the account under test |
+| The account under test | the deployed proxy. An externally-owned account cannot distinguish a conforming direct state write from an implementation that calls the destination, so it does not discharge the row above |
+| Spending consensus-credited value | an operation executed through the account moves value that arrived only by consensus credit |
+| Cross-client | identical balance and identical state root at every post-activation block, on ETC Mainnet (chainId 61) and Mordor Testnet (chainId 63) |
+| Published address | resolves to the same deployed code under every client implementation |
 
 ### Security Considerations
 
-The Olympia Treasury is designed as an immutable, governance-isolated vault whose only responsibilities are to receive protocol-level `BASEFEE` revenue and permit withdrawals from a single authorized executor defined in a separate ECIP. The following security considerations apply.
+**The one case that cannot be repaired at this layer is capture of the account's upgrade authority**, since every remedy at this layer is itself an execution through the captured path. **The remedy is a hard fork repointing the consensus address at a newly deployed account**, after which base fees arrive at the replacement from the new activation block onward.
 
-#### 1. Contract Immutability
+**That remedy bounds the worst case, and the bound is the design's central security claim.** The loss is the balance held at the moment of compromise plus the revenue credited between then and the new activation block. **The repair is coordination rather than invention:** the replacement is deployed and published on the same terms §"Deployment and Publication" already requires, and the instrument that installs the new address is the one that installed the original.
 
-- The Treasury contract MUST be deployed exactly once and MUST NOT contain any upgrade mechanisms.
-- No `delegatecall`, `selfdestruct`, proxy patterns, or privileged administrative keys SHALL be present.
-- Immutability ensures that neither the contract’s authorization logic nor its withdrawal behavior can be modified after deployment.
+**§"Balance Is the Source of Truth" is what keeps that bound true, and it is the highest-severity requirement in this ECIP.** The loss it guards against is the one the fork remedy above does not reach: funds at an address whose code cannot release them survive any repointing, because repointing moves later revenue and not the balance already held. It MUST be verified against every proposed implementation.
 
-#### 2. Access Control
+**Publication is a requirement because a misconfigured role fails invisibly.** A deployment whose roles are wrong produces a working system: value arrives, balances rise, and ordinary operations execute, so the defect surfaces only when someone acts through it. Publishing the role table is what lets a party who did not run the deployment check it against the specification that defines it.
 
-- Withdrawals MUST only succeed when initiated by the authorized executor address defined in a separate governance ECIP.
-- Until such an executor is deployed and configured, the withdrawal entry point MUST NOT be callable by any account or contract.
-- All unauthorized withdrawal attempts MUST revert.
+**Audit.** The deployed code is OpenZeppelin at a published release, so the audit obligation is one of configuration rather than of novel code. Third-party review MUST confirm, prior to Mainnet deployment, that the published address is the proxy rather than the implementation behind it, and that every published item reproduces from chain state. Testnet deployment MUST confirm accumulation, spendability of consensus-credited value, and cross-client consistency.
 
-This ensures that protocol-level funds remain securely locked during the accumulation phase and cannot be accessed prematurely.
+### Implementation
 
-#### 3. Consensus Enforcement
+**This ECIP requires no client behavior of its own.** [ECIP-1111](https://ecips.ethereumclassic.org/ECIPs/ecip-1111) states the consensus rule and the chain-configuration parameter holding the address, and a client implementing that ECIP implements everything this one needs.
 
-- Clients MUST correctly redirect all `BASEFEE` amounts to the Treasury address during block finalization as defined in ECIP-1111.
-- Any deviation from this rule SHALL cause a permanent consensus fork.
-- The Treasury contract itself performs no consensus logic; it relies on client implementations to uphold the protocol rules strictly.
+Prior to Mainnet activation the following MUST be published, so that §"Deployment and Publication" is checkable by a party who did not run the deployment:
 
-#### 4. Minimal Attack Surface
+- the **address together with the network it is on** — Mainnet's and Mordor's are independent values, so an address published without its chainId is ambiguous;
+- the **verified source and release tag** of every contract at and beneath it;
+- the **implementation the address delegates to**, read from the ERC-1967 implementation slot `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`, and **where upgrade authority rests**, read from the ERC-1967 admin slot `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103` and then that contract's `owner()` — both from chain state rather than from a deployment record, since that is what can change the logic behind a permanent address;
+- the **full role table of the account**, so that anyone can confirm which accounts may act through it and that no role which existed only to construct the deployment survives.
 
-- The Treasury MUST NOT implement governance logic, proposal validation, metadata hashing, or voting semantics.
-- Its design SHALL remain minimal and predictable, reducing potential vulnerabilities arising from complex logic.
-- The contract SHOULD track only what is necessary to prevent duplicate withdrawals, if applicable.
+Each item MUST be reproducible from chain state.
 
-#### 5. Deployment and Initialization Safety
+### Related ECIPs
 
-- At deployment, the executor address MUST be set to a value that cannot satisfy the Treasury’s authorization checks until the designated governance executor is deployed under a separate ECIP.
-- This ensures that all funds remain locked and inaccessible during the pre-governance accumulation period.
+| ECIP | Relationship to this ECIP |
+|---|---|
+| [1111](https://ecips.ethereumclassic.org/ECIPs/ecip-1111) | The consensus rule that credits this address, the chain-configuration parameter holding it, and the source of the requirement that the credit execute no EVM code |
 
-#### 6. Audit and Testing Requirements
+**The `requires:` field expresses spec layering.** The specification of how the account at this address is governed depends on this one, so that edge runs in the other direction and is recorded there.
 
-- The Treasury contract SHALL undergo third-party security audits prior to mainnet deployment.
-- Formal verification and static-analysis tools SHOULD be used to validate invariants such as:
-  - Correct access control  
-  - Absence of upgrade paths  
-  - Safe handling of Ether transfers  
-- Testnet deployments MUST confirm:
-  - Accurate `BASEFEE` accumulation  
-  - Correct rejection of unauthorized withdrawal attempts  
-  - Cross-client consistency under ECIP-1111 redirection  
+### References
 
-#### Security Considerations Summary
+Where a third-party repository is cited, the ref is a commit rather than a branch or tag: a commit cannot move, while a branch or tag resolves to different code over time and is therefore not a citation.
 
-The Olympia Treasury provides a secure and immutable custody layer for protocol-level revenue. Its minimal design, strict access control, and reliance on consensus-layer enforcement ensure that funds are safely accumulated and remain inaccessible until governance becomes active under separate ECIPs.
+1. OpenZeppelin Contracts, `TransparentUpgradeableProxy` and `ProxyAdmin`, https://github.com/OpenZeppelin/openzeppelin-contracts @ `e4f70216d759d8e6a64144a9e1f7bbeed78e7079` — release v5.3.0, the account §"What Is Deployed There" specifies. `contracts/proxy/transparent/TransparentUpgradeableProxy.sol` line 67, `address private immutable _admin`; line 72, `error ProxyDeniedAdminAccess()`; line 80, `_admin = address(new ProxyAdmin(initialOwner))`, the constructor being the only place that address is set; and the WARNING preceding the contract, against adding an external function that could shadow `upgradeToAndCall` by selector clash. `contracts/proxy/transparent/ProxyAdmin.sol` line 13, `contract ProxyAdmin is Ownable`, and line 42, `upgradeAndCall` restricted `onlyOwner`. `contracts/proxy/ERC1967/ERC1967Utils.sol` lines 21 and 83, the two slot constants §Implementation names
 
-### Related ECIPs in the Olympia Upgrade
+2. ERC-1967, "Proxy Storage Slots" (Final), https://eips.ethereum.org/EIPS/eip-1967 — the implementation and admin slots, each the keccak-256 hash of its label less one
 
-ECIP-1112 is one of four coordinated proposals that together define the Olympia framework for protocol-level funding on Ethereum Classic.
+3. GHSA-9rcw-c2f9-2j55 (CVE-2025-54070), https://github.com/OpenZeppelin/openzeppelin-contracts/security/advisories/GHSA-9rcw-c2f9-2j55 — affects `>= 5.2.0, < 5.4.0`, first patched at 5.4.0. The vulnerable code is `lastIndexOf` in `utils/Bytes.sol`, absent from the proxy's transitive import closure at every release across that range and through v5.7.0; the same walk finds it inside `Governor`'s closure at v5.4.0
 
-- **ECIP-1111 — Olympia EVM and Protocol Upgrades**  
-  Activates EIP-1559 and EIP-3198 on Ethereum Classic and redirects the `BASEFEE` amount to the Treasury address defined in this ECIP.
+4. OpenZeppelin Contracts, `Escrow`, https://github.com/OpenZeppelin/openzeppelin-contracts @ `dc44c9f1a4c3b10af99492eed84f83ed244203f6` — `contracts/utils/escrow/Escrow.sol`, where `deposit(address payee) public payable` credits `_deposits[payee]`: the pattern §"Balance Is the Source of Truth" excludes. That commit is release v4.9.6, the last to carry the escrow family: every v5 release from `932fddf69a699a9a80fd2396fd1a2ab91cdda123` (v5.0.0) through v5.7.0 carries no escrow contract at all
 
-- **ECIP-1112 — Olympia Treasury Contract**  
-  Defines the deterministic, immutable smart contract that receives and holds all redirected `BASEFEE` revenue in a governance-isolated vault.
+5. Liquity, https://github.com/liquity/dev @ `3e64ee1b52c50d51587c64c1cf75e0ba82934979` — `packages/contracts/contracts/ActivePool.sol`, where `receive() external payable` credits `uint256 internal ETH`: the same pattern, in the `receive()` body that a consensus-layer credit never enters
 
-- **ECIP-1113 — Olympia DAO Governance Framework**  
-  Specifies the governance architecture, including the authorized executor contract that is permitted to initiate Treasury withdrawals.
-
-- **ECIP-1114 — Ethereum Classic Funding Proposal Process**  
-  Defines the standardized proposal format and lifecycle used by the governance system to authorize Treasury disbursements.
-
-#### Interdependency Summary
-
-- **ECIP-1111** provides the protocol-level `BASEFEE` revenue source.  
-- **ECIP-1112** defines the immutable contract that stores this revenue.  
-- **ECIP-1113** establishes the governance executor permitted to withdraw funds.  
-- **ECIP-1114** defines the proposal structure and lifecycle used by governance to authorize withdrawals.
-
-These ECIPs are designed for **modular activation**:
-
-- ECIP-1111 and ECIP-1112 MAY be activated first to begin revenue accumulation.  
-- ECIP-1113 and ECIP-1114 MAY be deployed later to enable controlled, on-chain authorization of Treasury withdrawals.
+6. ECIP-1111 (2025), "Base Fee Market and Redirection" — the consensus rule, §"The Destination Address" for the chain-configuration parameter, and §"Test Cases" for the credit vectors this ECIP runs against the deployed proxy
 
 ### Copyright
 
-Copyright and related rights waived via  
-[CC0](https://creativecommons.org/publicdomain/zero/1.0/)
-
-### Appendix: EVM Precedents for Treasury Design
-
-Several EVM-based networks use deterministic, contract-based mechanisms for receiving protocol-level fees or revenue. These designs demonstrate established patterns for routing endogenous network value into transparent, on-chain custody locations that operate independently of execution or governance logic.
-
-#### Treasury Design Precedents
-
-| Network           | Mechanism                                           | Notes                                                                 |
-|-------------------|------------------------------------------------------|-----------------------------------------------------------------------|
-| **Ronin**         | Redirects EIP-1559 `BASEFEE` to a fixed contract     | Demonstrates contract-based receipt of protocol-level fees            |
-| **Celo**          | Gas fees sent to a contract-based fee handler        | Illustrates transparent custody of on-chain revenue                   |
-| **Mantle**        | Sequencer revenue accumulated at a known contract    | Shows deterministic contract endpoints for protocol-level inflows     |
-| **Polygon CDK**   | Optional fee hooks directing value to contracts      | Supports contract-level receipt of network fees in modular rollups    |
-| **OP Stack**      | Sequencer revenue forwarded to fixed contract sinks  | Example of predictable programmatic fee routing                       |
-| **Arbitrum**      | Sequencer fees accumulated at a contract address     | Illustrates transparent on-chain fund accumulation                    |
-| **Optimism**      | Revenue routed to designated on-chain custody        | Reinforces patterns for deterministic fee sinks                       |
-| **Avalanche Subnets** | Transaction fees routed to subnet contracts     | Demonstrates per-subnet contract-level custody                        |
-| **Gitcoin DAO**   | Uses contract-based treasuries for on-chain funds    | Relevant for transparent custody rather than governance mechanics      |
-
-#### Design Principles Relevant to ECIP-1112
-
-- **Immutable Contract Custody**  
-  Several networks use contracts with no upgrade mechanisms to provide predictable, tamper-resistant storage of protocol-level value.
-
-- **Deterministic Addresses**  
-  Many systems deploy fee-receiving contracts at fixed or precomputed addresses to ensure consistent cross-client behavior.
-
-- **Automatic Revenue Routing**  
-  Protocol-defined flows (e.g., `BASEFEE`, gas fees, sequencer revenue) are commonly forwarded directly into a contract without discretionary control.
-
-- **Transparent On-Chain Accounting**  
-  Contract-based treasuries allow all inflows to be observed and audited directly on-chain.
-
-ECIP-1112 adopts these proven design patterns by defining an immutable, deterministic Treasury contract that receives protocol-level `BASEFEE` revenue redirected under ECIP-1111, while leaving governance and allocation mechanics to separate ECIPs.
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Updates ECIP-1112 to the post-implementation draft, reflecting the specification as built rather than as originally proposed.

Title is now **Sovereignty Vault**, matching the term ECIP-1111 uses for the chain-configuration parameter holding the address.

The account is specified by three properties readable from chain state rather than by a named contract at a named release, so changing the deployed release is a deployment decision rather than an amendment here.

Cross-references ECIP-1111 §"The Destination Address" and §"Test Cases", which land in #584.